### PR TITLE
fix: Suppress legacy history warnings and improve killed process messaging (rc.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+**Suppressed Alarming Schema Validation Warnings for Legacy History**
+- **Problem**: After upgrading from rc.9, users saw confusing warnings about "Invalid ValidationResult" and "Skipping corrupted run entry"
+  - These warnings were caused by legacy history entries from rc.9 with 0/0 line/column values (fixed extractor bug in rc.10)
+  - Warnings were correct (entries violated schema), but alarming and repetitive (appeared on every validation)
+  - Confused users into thinking current validation was broken
+- **Solution**: Silently skip corrupted legacy entries
+  - Reader now filters out invalid runs without spamming warnings
+  - Users can optionally cleanup with: `vv history prune --all`
+  - After any upgrade, run `vv doctor` to check for issues
+- **Impact**: Clean validation output, no more alarming warnings for legacy data
+
+**Fixed Misleading "0 test failure(s)" for Killed Processes**
+- **Problem**: When fail-fast killed a slow process, extraction showed "0 test failure(s)" which was misleading
+  - Killed processes had exitCode=1 but empty output
+  - Extractor reported "0 errors" since it found no output to extract
+  - Confused users about why the step failed
+- **Solution**: Detect killed processes (minimal output + non-zero exit) and provide meaningful extraction
+  - Summary: "Process stopped (fail-fast)"
+  - Guidance: "This step was terminated when another step failed. Check the failed step above for the root cause."
+  - Clearly indicates the step was stopped, not that it passed
+- **Impact**: Users now understand fail-fast behavior and can quickly identify the root cause
+
 ## [0.17.0-rc.10] - 2025-11-28
 
 ### 🐛 Bug Fixes

--- a/packages/history/src/reader.ts
+++ b/packages/history/src/reader.ts
@@ -40,17 +40,17 @@ export async function readHistoryNote(
     }
 
     // Validate each ValidationResult in runs array using safe validation
+    // Silently skip corrupted entries (e.g., legacy 0/0 line/column from rc.9)
+    // After upgrading vibe-validate, run 'vv doctor' to check for issues
+    // Users can optionally cleanup old history with: vv history prune --all
     const validatedRuns = [];
     for (const run of parsed.runs) {
       if (!run.result) {
-        console.warn(`Run ${run.id} missing result field - skipping`);
         continue;
       }
 
       const validationResult = safeValidateResult(run.result);
       if (!validationResult.success) {
-        console.warn(`Invalid ValidationResult in run ${run.id}:`, validationResult.errors);
-        console.warn('Skipping corrupted run entry');
         continue;
       }
 


### PR DESCRIPTION
## Summary

Fixes two user-reported issues discovered in dogfooding manuscript-lsp-mcp with rc.10:

1. **Alarming schema validation warnings** for legacy history entries from rc.9
2. **Misleading "0 test failure(s)"** message for killed processes in fail-fast mode

## Problem Details

### Issue 1: Alarming Legacy History Warnings
After upgrading from rc.9 to rc.10, users saw confusing warnings on **every validation run**:
```
Invalid ValidationResult in run run-1764370977498: [
  'phases.0.steps.1.extraction.errors.0.line: Number must be greater than 0',
  'phases.0.steps.1.extraction.errors.0.column: Number must be greater than 0',
  ...
]
Skipping corrupted run entry
```

**Root cause**: 
- rc.9 had a bug where extractors sometimes reported line/column as 0/0
- rc.10 fixed the extractor bug and added schema validation
- Legacy history entries from rc.9 now violate the schema (line/column must be >0)
- Reader warned about every corrupted entry, creating alarming output

### Issue 2: Misleading Killed Process Message
When fail-fast killed a slow process, the output showed:
```yaml
- name: TypeScript Tests
  command: npm run test
  exitCode: 1
  passed: false
  extraction:
    summary: 0 test failure(s)
    totalErrors: 0
    errors: []
```

**Root cause**:
- Process was killed before it could output anything
- Extractor found no output to extract
- Reported "0 errors" even though step failed (exitCode=1)
- Confused users about why the step failed

## Solution

### Fix 1: Silently Skip Corrupted Legacy Entries
**File**: `packages/history/src/reader.ts`

- Filter out invalid runs without spamming warnings
- Clean, simple code (no DEBUG mode complexity)
- Users can optionally cleanup with: `vv history prune --all`
- Reinforces existing best practice: **"After upgrade, run `vv doctor`"**

**Impact**: Clean validation output, no more alarming warnings

### Fix 2: Detect and Handle Killed Processes  
**File**: `packages/core/src/runner.ts`

- Detect killed processes: minimal output (<50 chars) + non-zero exit code
- Provide meaningful extraction:
  ```yaml
  extraction:
    summary: "Process stopped (fail-fast)"
    totalErrors: 0
    errors: []
    guidance: "This step was terminated when another step failed. Check the failed step above for the root cause."
  ```

**Impact**: Users now understand fail-fast behavior and can quickly identify root cause

## Testing

✅ **Added comprehensive tests**:
- `packages/core/test/runner.test.ts` - Test killed process extraction
- `packages/history/test/reader.test.ts` - Test legacy 0/0 corruption handling

✅ **Both tests passing** (exitCode: 0)

✅ **Pre-commit validation passed**:
- Secret scanning: ✅ No secrets detected
- Validation: ✅ Already passed for working tree
- All checks passed

## Changes

- `packages/history/src/reader.ts` - Silently skip corrupted entries
- `packages/core/src/runner.ts` - Detect and handle killed processes
- `CHANGELOG.md` - Document fixes with user-focused messaging
- `packages/core/test/runner.test.ts` - Add test for killed processes
- `packages/history/test/reader.test.ts` - Add test for corrupted entries

## User Message

**After upgrading vibe-validate, run `vv doctor` to check for issues.**

## Release Notes

This fix will go into rc.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)