### PR TITLE
fix: Use umbrella package for version in Check 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vibe-validate",
+  "version": "0.18.4",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/dev-tools/src/pre-publish-check.ts
+++ b/packages/dev-tools/src/pre-publish-check.ts
@@ -540,16 +540,16 @@ if (skipGitChecks) {
   console.log('Checking CHANGELOG.md...');
 
   try {
-    // Read version from core package (monorepo canonical version)
-    const corePkgJsonPath = join(packagesDir, 'core', 'package.json');
-    if (!existsSync(corePkgJsonPath)) {
-      throw new Error('Core package.json not found');
+    // Read version from umbrella package (monorepo canonical version)
+    const umbrellaPkgJsonPath = join(packagesDir, 'vibe-validate', 'package.json');
+    if (!existsSync(umbrellaPkgJsonPath)) {
+      throw new Error('Umbrella package (vibe-validate) package.json not found');
     }
 
-    const corePkgJson = JSON.parse(readFileSync(corePkgJsonPath, 'utf8')) as Record<string, unknown>;
-    const version = corePkgJson['version'];
+    const umbrellaPkgJson = JSON.parse(readFileSync(umbrellaPkgJsonPath, 'utf8')) as Record<string, unknown>;
+    const version = umbrellaPkgJson['version'];
     if (typeof version !== 'string') {
-      throw new TypeError('Version not found in core package.json');
+      throw new TypeError('Version not found in umbrella package (vibe-validate) package.json');
     }
 
     // Read CHANGELOG.md


### PR DESCRIPTION
# Use Umbrella Package for Version Source

Fixes Check 11 to use the semantically correct package for version checking.

## Changes

### 1. Add Version to Root Package.json
- Added `"version": "0.18.4"` to root package.json
- Consistency with vibe-agent-toolkit (which has root version)
- bump-version now updates root instead of skipping with "no-version"
- More explicit: see monorepo version at a glance

### 2. Fix Check 11 to Use Umbrella Package
- **Before:** Read from `packages/core/package.json`
- **After:** Read from `packages/vibe-validate/package.json` (umbrella)
- **Why:** Umbrella package is the canonical monorepo version
  - Explicitly marked as "Umbrella package" in package-lists.ts
  - Last in dependency order (depends on all others)
  - The package users actually install

## Testing

```bash
# Verify CHANGELOG check works with umbrella package
pnpm exec tsx packages/dev-tools/src/pre-publish-check.ts
# ✅ CHANGELOG.md has entry for version 0.18.4

# Verify bump-version updates root
pnpm bump-version 0.18.4
# ✓ vibe-validate: 0.18.4 → 0.18.4 (instead of "skipped (no-version)")
```

## Impact

- More semantically correct version source
- Consistent with vibe-agent-toolkit approach
- Root version now managed by bump-version

## Next Steps

Apply same improvement to vibe-agent-toolkit (Check 11 + umbrella package)

🤖 Generated with [Claude Code](https://claude.ai/code)