### PR TITLE
fix: move CI permissions and env to job-level scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`generate-workflow` hardening** — `ci.permissions` and `ci.env` are now applied to the `validate` and `coverage` jobs instead of at workflow level, so the `all-validation-passed` gate job no longer inherits unnecessary access (resolves SonarQube workflow-level permissions flag). Also fixed check script indentation and build step auto-detection (no longer matches on step name substring — checks `package.json` for a `build` script instead).
 - **`watch-pr` crashes on repos with non-main default branch** — `fetchFileChanges` hardcoded `origin/main` for git diff, causing failures on repos using `master`, `develop`, or other base branches. Now uses the PR's actual base branch from GitHub metadata.
-- **`generate-workflow` check script indentation** — The `all-validation-passed` gate job's bash script had excessive indentation, now uses standard 2-space indent
-- **`generate-workflow` build step auto-detection** — No longer matches on step name substring (e.g., "dotnet build" falsely triggered `npm run build`). Now checks `package.json` for a `build` script instead.
 
 ## [0.19.0] - 2026-03-04
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.1-rc.1 # Tracks vibe-validate package version
+version: 0.19.1-rc.2 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/generate-workflow.ts
+++ b/packages/cli/src/commands/generate-workflow.ts
@@ -66,6 +66,7 @@ interface GitHubWorkflowStep {
 interface GitHubWorkflowJob {
   name: string;
   'runs-on': string;
+  permissions?: Record<string, string>;
   needs?: string[];
   if?: string;
   steps: GitHubWorkflowStep[];
@@ -76,6 +77,7 @@ interface GitHubWorkflowJob {
       node: string[];
     };
   };
+  env?: Record<string, string>;
 }
 
 /**
@@ -84,12 +86,10 @@ interface GitHubWorkflowJob {
 interface GitHubWorkflow {
   name: string;
   on: unknown;
-  permissions?: Record<string, string>;
   concurrency?: {
     group: string;
     'cancel-in-progress'?: boolean;
   };
-  env?: Record<string, string>;
   jobs: Record<string, GitHubWorkflowJob>;
 }
 
@@ -267,15 +267,15 @@ function buildCommonJobSteps(params: {
 }
 
 /**
- * Build the top-level workflow metadata (permissions, concurrency, env)
- * from the vibe-validate config.
+ * Build the top-level workflow metadata (concurrency only).
+ *
+ * Permissions and env are applied at the job level, not the workflow level.
+ * This avoids granting permissions to jobs that don't need them (e.g., the
+ * gate job only checks results and needs no special access). SonarQube and
+ * other security scanners flag workflow-level permissions as a vulnerability.
  */
-function buildWorkflowMetadata(config: VibeValidateConfig): Pick<GitHubWorkflow, 'permissions' | 'concurrency' | 'env'> {
-  const metadata: Pick<GitHubWorkflow, 'permissions' | 'concurrency' | 'env'> = {};
-
-  if (config.ci?.permissions) {
-    metadata.permissions = config.ci.permissions;
-  }
+function buildWorkflowMetadata(config: VibeValidateConfig): Pick<GitHubWorkflow, 'concurrency'> {
+  const metadata: Pick<GitHubWorkflow, 'concurrency'> = {};
 
   if (config.ci?.concurrency) {
     const concurrency: GitHubWorkflow['concurrency'] = {
@@ -285,6 +285,20 @@ function buildWorkflowMetadata(config: VibeValidateConfig): Pick<GitHubWorkflow,
       concurrency['cancel-in-progress'] = config.ci.concurrency.cancelInProgress;
     }
     metadata.concurrency = concurrency;
+  }
+
+  return metadata;
+}
+
+/**
+ * Build job-level metadata (permissions, env) from the vibe-validate config.
+ * Applied to validate and coverage jobs, but NOT to the gate job.
+ */
+function buildJobMetadata(config: VibeValidateConfig): Pick<GitHubWorkflowJob, 'permissions' | 'env'> {
+  const metadata: Pick<GitHubWorkflowJob, 'permissions' | 'env'> = {};
+
+  if (config.ci?.permissions) {
+    metadata.permissions = config.ci.permissions;
   }
 
   if (config.ci?.env) {
@@ -348,9 +362,12 @@ export function generateWorkflow(
     },
   });
 
+  const jobMetadata = buildJobMetadata(config);
+
   jobs['validate'] = {
     name: 'Run vibe-validate validation',
     'runs-on': '${{ matrix.os }}',
+    ...jobMetadata,
     steps: jobSteps,
     strategy: {
       'fail-fast': matrixFailFast,
@@ -393,6 +410,7 @@ export function generateWorkflow(
     jobs['validate-coverage'] = {
       name: 'Run validation with coverage',
       'runs-on': DEFAULT_RUNNER_OS,
+      ...jobMetadata,
       steps: coverageSteps,
     };
   }

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.1-rc.1'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.1-rc.2'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/commands/generate-workflow.test.ts
+++ b/packages/cli/test/commands/generate-workflow.test.ts
@@ -751,8 +751,8 @@ describe('generate-workflow command', () => {
       });
     });
 
-    describe('F2: workflow-level env', () => {
-      it('should add workflow-level env block when ci.env is set', () => {
+    describe('F2: job-level env', () => {
+      it('should add env to validate job when ci.env is set', () => {
         const config: VibeValidateConfig = {
           ...baseMockConfig,
           ci: { env: { NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}', CI: 'true' } },
@@ -760,21 +760,35 @@ describe('generate-workflow command', () => {
 
         const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
 
-        expect(workflow.env).toEqual({
+        // env should be on the validate job, not at workflow level
+        expect(workflow.env).toBeUndefined();
+        expect(workflow.jobs['validate'].env).toEqual({
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}',
           CI: 'true',
         });
+      });
+
+      it('should NOT add env to gate job', () => {
+        const config: VibeValidateConfig = {
+          ...baseMockConfig,
+          ci: { env: { NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}' } },
+        };
+
+        const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
+
+        expect(workflow.jobs['all-validation-passed'].env).toBeUndefined();
       });
 
       it('should NOT add env block when ci.env is not set', () => {
         const workflow = generateAndParseWorkflow(baseMockConfig, { packageManager: 'pnpm' });
 
         expect(workflow.env).toBeUndefined();
+        expect(workflow.jobs['validate'].env).toBeUndefined();
       });
     });
 
-    describe('F3: permissions block', () => {
-      it('should add permissions block when ci.permissions is set', () => {
+    describe('F3: permissions block (job-level)', () => {
+      it('should add permissions to validate job when ci.permissions is set', () => {
         const config: VibeValidateConfig = {
           ...baseMockConfig,
           ci: { permissions: { contents: 'read', packages: 'write' } },
@@ -782,13 +796,41 @@ describe('generate-workflow command', () => {
 
         const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
 
-        expect(workflow.permissions).toEqual({ contents: 'read', packages: 'write' });
+        // permissions should be on the validate job, not at workflow level
+        expect(workflow.permissions).toBeUndefined();
+        expect(workflow.jobs['validate'].permissions).toEqual({ contents: 'read', packages: 'write' });
+      });
+
+      it('should NOT add permissions to gate job', () => {
+        const config: VibeValidateConfig = {
+          ...baseMockConfig,
+          ci: { permissions: { packages: 'read' } },
+        };
+
+        const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
+
+        expect(workflow.jobs['all-validation-passed'].permissions).toBeUndefined();
+      });
+
+      it('should add permissions to coverage job when enabled', () => {
+        const config: VibeValidateConfig = {
+          ...baseMockConfig,
+          ci: { permissions: { packages: 'read' } },
+        };
+
+        const workflow = generateAndParseWorkflow(config, {
+          packageManager: 'pnpm',
+          enableCoverage: true,
+        });
+
+        expect(workflow.jobs['validate-coverage'].permissions).toEqual({ packages: 'read' });
       });
 
       it('should NOT add permissions block when ci.permissions is not set', () => {
         const workflow = generateAndParseWorkflow(baseMockConfig, { packageManager: 'pnpm' });
 
         expect(workflow.permissions).toBeUndefined();
+        expect(workflow.jobs['validate'].permissions).toBeUndefined();
       });
     });
 
@@ -996,7 +1038,7 @@ describe('generate-workflow command', () => {
     });
 
     describe('YAML property ordering', () => {
-      it('should output workflow properties in order: name, on, permissions, concurrency, env, jobs', () => {
+      it('should output workflow properties in order: name, on, concurrency, jobs', () => {
         const config: VibeValidateConfig = {
           ...baseMockConfig,
           ci: {
@@ -1011,16 +1053,17 @@ describe('generate-workflow command', () => {
         // Find positions of top-level keys in the YAML output
         const namePos = workflowYaml.indexOf('\nname:');
         const onPos = workflowYaml.includes('\n"on":') ? workflowYaml.indexOf('\n"on":') : workflowYaml.indexOf('\non:');
-        const permissionsPos = workflowYaml.indexOf('\npermissions:');
         const concurrencyPos = workflowYaml.indexOf('\nconcurrency:');
-        const envPos = workflowYaml.indexOf('\nenv:');
         const jobsPos = workflowYaml.indexOf('\njobs:');
 
         expect(namePos).toBeLessThan(onPos);
-        expect(onPos).toBeLessThan(permissionsPos);
-        expect(permissionsPos).toBeLessThan(concurrencyPos);
-        expect(concurrencyPos).toBeLessThan(envPos);
-        expect(envPos).toBeLessThan(jobsPos);
+        expect(onPos).toBeLessThan(concurrencyPos);
+        expect(concurrencyPos).toBeLessThan(jobsPos);
+
+        // permissions and env should NOT appear at workflow level
+        // (they are on the validate job instead)
+        expect(workflowYaml).not.toMatch(/^permissions:/m);
+        expect(workflowYaml).not.toMatch(/^env:/m);
       });
     });
   });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.1-rc.1",
+  "version": "0.19.1-rc.2",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Move `ci.permissions` and `ci.env` from workflow-level to job-level in the generated `validate.yml`
- Only the `validate` and `coverage` jobs receive these settings — the `all-validation-passed` gate job inherits nothing it doesn't need
- `concurrency` remains at workflow level (governs the whole workflow)

## Why

Security scanners (SonarQube, etc.) flag workflow-level `permissions` blocks as a vulnerability because they grant access to **all** jobs indiscriminately. The gate job only runs a bash `if` check on job results — it needs no special permissions, env vars, or registry access.

This makes the generated workflow more surgical: each job declares exactly what it needs, and the gate job runs with minimal defaults.

## Breaking change?

No. The generated workflow produces identical CI behavior. The only difference is where `permissions` and `env` appear in the YAML (job-level vs workflow-level). Downstream repos will see a diff when they run `generate-workflow` after upgrading, but the workflow behavior is unchanged.

## Test plan

- [x] All 2,471 unit tests pass (68 in generate-workflow.test.ts)
- [x] `vv validate` passes (Pre-Qualification + Testing)
- [x] Updated tests verify permissions/env are on validate job, NOT at workflow level
- [x] New tests verify gate job has no permissions or env
- [x] New tests verify coverage job gets permissions when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)