### PR TITLE
fix: auto-inject contents:read when ci.permissions is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`generate-workflow` hardening** — `ci.permissions` and `ci.env` are now applied to the `validate` and `coverage` jobs instead of at workflow level, so the `all-validation-passed` gate job no longer inherits unnecessary access (resolves SonarQube workflow-level permissions flag). Also fixed check script indentation and build step auto-detection (no longer matches on step name substring — checks `package.json` for a `build` script instead).
+- **`generate-workflow` hardening** — `ci.permissions` and `ci.env` are now applied to the `validate` and `coverage` jobs instead of at workflow level, so the `all-validation-passed` gate job no longer inherits unnecessary access (resolves SonarQube workflow-level permissions flag). `contents: read` is auto-injected when `ci.permissions` is set, since job-level permissions replace all defaults and `actions/checkout` always needs it. Also fixed check script indentation and build step auto-detection (no longer matches on step name substring — checks `package.json` for a `build` script instead).
 - **`watch-pr` crashes on repos with non-main default branch** — `fetchFileChanges` hardcoded `origin/main` for git diff, causing failures on repos using `master`, `develop`, or other base branches. Now uses the PR's actual base branch from GitHub metadata.
 
 ## [0.19.0] - 2026-03-04

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.1-rc.2 # Tracks vibe-validate package version
+version: 0.19.1-rc.3 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/generate-workflow.ts
+++ b/packages/cli/src/commands/generate-workflow.ts
@@ -298,7 +298,9 @@ function buildJobMetadata(config: VibeValidateConfig): Pick<GitHubWorkflowJob, '
   const metadata: Pick<GitHubWorkflowJob, 'permissions' | 'env'> = {};
 
   if (config.ci?.permissions) {
-    metadata.permissions = config.ci.permissions;
+    // Job-level permissions replace all defaults — actions/checkout always
+    // needs contents:read, so inject it automatically if not already present.
+    metadata.permissions = { contents: 'read', ...config.ci.permissions };
   }
 
   if (config.ci?.env) {

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.1-rc.2'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.1-rc.3'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/commands/generate-workflow.test.ts
+++ b/packages/cli/test/commands/generate-workflow.test.ts
@@ -791,7 +791,7 @@ describe('generate-workflow command', () => {
       it('should add permissions to validate job when ci.permissions is set', () => {
         const config: VibeValidateConfig = {
           ...baseMockConfig,
-          ci: { permissions: { contents: 'read', packages: 'write' } },
+          ci: { permissions: { packages: 'write' } },
         };
 
         const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
@@ -799,6 +799,30 @@ describe('generate-workflow command', () => {
         // permissions should be on the validate job, not at workflow level
         expect(workflow.permissions).toBeUndefined();
         expect(workflow.jobs['validate'].permissions).toEqual({ contents: 'read', packages: 'write' });
+      });
+
+      it('should auto-inject contents:read for actions/checkout', () => {
+        const config: VibeValidateConfig = {
+          ...baseMockConfig,
+          ci: { permissions: { packages: 'read' } },
+        };
+
+        const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
+
+        // contents:read is required for actions/checkout and must always be present
+        expect(workflow.jobs['validate'].permissions).toEqual({ contents: 'read', packages: 'read' });
+      });
+
+      it('should not override explicit contents permission', () => {
+        const config: VibeValidateConfig = {
+          ...baseMockConfig,
+          ci: { permissions: { contents: 'write', packages: 'read' } },
+        };
+
+        const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
+
+        // User-specified contents:write should take precedence over the default
+        expect(workflow.jobs['validate'].permissions).toEqual({ contents: 'write', packages: 'read' });
       });
 
       it('should NOT add permissions to gate job', () => {
@@ -823,7 +847,7 @@ describe('generate-workflow command', () => {
           enableCoverage: true,
         });
 
-        expect(workflow.jobs['validate-coverage'].permissions).toEqual({ packages: 'read' });
+        expect(workflow.jobs['validate-coverage'].permissions).toEqual({ contents: 'read', packages: 'read' });
       });
 
       it('should NOT add permissions block when ci.permissions is not set', () => {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.1-rc.2",
+  "version": "0.19.1-rc.3",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Auto-inject `contents: read` into job-level permissions whenever `ci.permissions` is configured
- User-specified `contents` values (e.g., `contents: write`) take precedence
- Bump to `0.19.1-rc.3`

## Why

Follow-up to PR #141 (job-level permissions). Job-level `permissions` in GitHub Actions **replace** all defaults — unlike workflow-level permissions which narrow them. This means `actions/checkout` fails with "repository not found" on private repos unless `contents: read` is explicitly listed.

Rather than requiring every consumer to remember this, vibe-validate now handles it automatically.

## Test plan

- [x] All 70 generate-workflow tests pass (2 new: auto-inject test + precedence test)
- [x] `vv validate` passes (Pre-Qualification + Testing)
- [x] Verified: config with only `packages: read` produces `{ contents: read, packages: read }` in YAML
- [x] Verified: config with `contents: write` preserves `write` (not overridden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)