### PR TITLE
feat: Add Claude marketplace distribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,9 +67,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ steps.version_type.outputs.is_stable }}" = "true" ]; then
-            pnpm exec vat claude marketplace publish --cwd packages/vibe-validate
+            pnpm --filter vibe-validate exec vat claude marketplace publish
           else
-            pnpm exec vat claude marketplace publish --cwd packages/vibe-validate --branch claude-marketplace-next
+            pnpm --filter vibe-validate exec vat claude marketplace publish --branch claude-marketplace-next
           fi
 
       - name: Extract CHANGELOG for release (stable only)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
+      - name: Publish Claude marketplace
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.version_type.outputs.is_stable }}" = "true" ]; then
+            pnpm exec vat claude marketplace publish --cwd packages/vibe-validate
+          else
+            pnpm exec vat claude marketplace publish --cwd packages/vibe-validate --branch claude-marketplace-next
+          fi
+
       - name: Extract CHANGELOG for release (stable only)
         if: steps.version_type.outputs.is_stable == 'true'
         id: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-04-10
+
 ### Added
 
 - **Claude marketplace distribution** — Users can now install the vibe-validate skill directly from GitHub via `claude plugin marketplace add jdutton/vibe-validate#claude-marketplace`, no npm account required. Pre-release channel available via `claude-marketplace-next` branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Claude marketplace distribution** — Users can now install the vibe-validate skill directly from GitHub via `claude plugin marketplace add jdutton/vibe-validate#claude-marketplace`, no npm account required. Pre-release channel available via `claude-marketplace-next` branch.
+
 ## [0.19.1] - 2026-04-01
 
 ### Added

--- a/docs/marketplace-readme.md
+++ b/docs/marketplace-readme.md
@@ -1,0 +1,58 @@
+# vibe-validate Skills Marketplace
+
+LLM-optimized validation orchestration for vibe coding. [vibe-validate](https://github.com/jdutton/vibe-validate) caches validation state using git tree hashes, runs steps in parallel, and formats errors for LLM consumption.
+
+**What you get:** A skill that teaches Claude Code how to configure and use vibe-validate for pre-commit workflows, CI validation, and error extraction in TypeScript projects.
+
+## Install
+
+### For yourself (user-level)
+
+```bash
+claude plugin marketplace add jdutton/vibe-validate#claude-marketplace
+claude plugin install vibe-validate@vibe-validate
+```
+
+### For your project (shared with team)
+
+```bash
+claude plugin marketplace add jdutton/vibe-validate#claude-marketplace --scope project
+claude plugin install vibe-validate@vibe-validate
+```
+
+Project-scope writes to `.claude/settings.json` (committed to git). Team members
+who clone the repo will be prompted to install the marketplace automatically.
+
+### Update
+
+```bash
+claude plugin marketplace update vibe-validate
+```
+
+Then start a new Claude Code session. The skill appears as `/vibe-validate:vibe-validate`.
+
+### Pre-release channel
+
+To track the latest pre-release builds, use the `-next` branch instead:
+
+```bash
+claude plugin marketplace add jdutton/vibe-validate#claude-marketplace-next
+```
+
+## How it works
+
+This branch is a **Claude plugin marketplace** — a structured directory that Claude Code can install directly from GitHub. No npm account or registry needed.
+
+The marketplace is built from the [main branch](https://github.com/jdutton/vibe-validate) source using `vat build` and published with `vat claude marketplace publish`.
+
+## Also available via npm
+
+```bash
+npm install -g vibe-validate
+```
+
+The npm package includes a postinstall hook that automatically registers the plugin in Claude Code.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.2-rc.4'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.2'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.2-rc.2'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.2-rc.3'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.2-rc.3'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.2-rc.4'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.2-rc.1'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.2-rc.2'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.1'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.2-rc.1'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.2-rc.1 # Tracks vibe-validate package version
+version: 0.19.2-rc.2 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.1 # Tracks vibe-validate package version
+version: 0.19.2-rc.1 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.2-rc.4 # Tracks vibe-validate package version
+version: 0.19.2 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.2-rc.3 # Tracks vibe-validate package version
+version: 0.19.2-rc.4 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.2-rc.2 # Tracks vibe-validate package version
+version: 0.19.2-rc.3 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.3",
+  "version": "0.19.2-rc.4",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.1",
+  "version": "0.19.2-rc.2",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.4",
+  "version": "0.19.2",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2-rc.2",
+  "version": "0.19.2-rc.3",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.1",
+  "version": "0.19.2-rc.1",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {
@@ -59,7 +59,7 @@
   "dependencies": {
     "@vibe-validate/cli": "workspace:*",
     "@vibe-validate/utils": "workspace:*",
-    "vibe-agent-toolkit": "^0.1.22"
+    "vibe-agent-toolkit": "^0.1.26"
   },
   "devDependencies": {
     "@types/node": "^20.19.26",

--- a/packages/vibe-validate/vibe-agent-toolkit.config.yaml
+++ b/packages/vibe-validate/vibe-agent-toolkit.config.yaml
@@ -15,6 +15,8 @@ claude:
     vibe-validate:
       owner:
         name: vibe-validate
+      publish:
+        branch: claude-marketplace
       plugins:
         - name: vibe-validate
           description: LLM-optimized validation orchestration for vibe coding

--- a/packages/vibe-validate/vibe-agent-toolkit.config.yaml
+++ b/packages/vibe-validate/vibe-agent-toolkit.config.yaml
@@ -17,6 +17,9 @@ claude:
         name: vibe-validate
       publish:
         branch: claude-marketplace
+        changelog: ../../CHANGELOG.md
+        readme: ../../docs/marketplace-readme.md
+        license: mit
       plugins:
         - name: vibe-validate
           description: LLM-optimized validation orchestration for vibe coding

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,8 +332,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       vibe-agent-toolkit:
-        specifier: ^0.1.22
-        version: 0.1.22
+        specifier: ^0.1.26
+        version: 0.1.26
     devDependencies:
       '@types/node':
         specifier: ^20.19.26
@@ -1244,44 +1244,44 @@ packages:
     resolution: {integrity: sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vibe-agent-toolkit/agent-config@0.1.22':
-    resolution: {integrity: sha512-Gs2pDYzltdx/srAF+0Pvl7QvzW+F8x2OvqcjJPznW+Z73dWZPHkDyK7I+qWNVMeOffujX+UTszp56YVm80oRnQ==}
+  '@vibe-agent-toolkit/agent-config@0.1.26':
+    resolution: {integrity: sha512-DMtOdMcrzpG7kFxR8pClm3OEPSzNlowaH8+2cekwpgRoYGotgq2e5k0bnq7CvWiBF3DgwyPANu4WnQPKmvzt0A==}
 
-  '@vibe-agent-toolkit/agent-schema@0.1.22':
-    resolution: {integrity: sha512-vh/LyamYn/WwPgZvP6YK0Od4ZJyiW4mcSnTJ9sEUm9wCfi3IkLPmoHHhWOcx6oepXwKGMkmAmOhYI45rtntbzA==}
+  '@vibe-agent-toolkit/agent-schema@0.1.26':
+    resolution: {integrity: sha512-Kpa7CSJ9NYZqGFtJfm5LCIXqti9E8Fp59MVSqOgxQb6tA6Dyy70CEQfQEN7E00dsG4MckWc1Y17wT52qPnwSlQ==}
 
-  '@vibe-agent-toolkit/agent-skills@0.1.22':
-    resolution: {integrity: sha512-+aLSXE6aq2gzHd0FSnmzFkEPWB1sF+jYjfwqqaOvRKrVhb7pNdFtS21PJD0Y7WYvJgcfixTqedP/WWLjVXcRwA==}
+  '@vibe-agent-toolkit/agent-skills@0.1.26':
+    resolution: {integrity: sha512-WhhrA9x9iDlq5pAmd2MLROYTVOHC6HxtAK/wkfgGouHJLsEdF/Uxcno6ky0KS/b89m17xAc/rFkMf2PB/0rqig==}
 
-  '@vibe-agent-toolkit/claude-marketplace@0.1.22':
-    resolution: {integrity: sha512-uHOPSJ2m8NEJcUDJw1Ve7SHfhFHjCkVP8DNKeJHF37b73IeSZokZ0gEaJR+1W7hC816O8WJen6kM4kd6v2jxFA==}
+  '@vibe-agent-toolkit/claude-marketplace@0.1.26':
+    resolution: {integrity: sha512-uOVIAAJ2iH0yD2czcUR+vJ71KDey6g/QONzWz0UHcZvy7baS2S9m78KhBTjsKvlHx6BmiVYMdYQ/pxHgqt4mow==}
 
-  '@vibe-agent-toolkit/cli@0.1.22':
-    resolution: {integrity: sha512-u+tNcrINruabK7igv+dEfCy9Hxc13G+dsJm6BgW2s3zUBEs+5y6oRWUWusjiRjZdYVPWe9LuKTKWYupsYaxG2A==}
+  '@vibe-agent-toolkit/cli@0.1.26':
+    resolution: {integrity: sha512-sGqukwuwqeo1YW0zN+zsaKU05MgWWpSO9yciwTqyEjJTFDCiYTa0BCnNwnT9ZzscCHIQxtKzRFCEyudcvUYWXA==}
     hasBin: true
 
-  '@vibe-agent-toolkit/discovery@0.1.22':
-    resolution: {integrity: sha512-DrjFJfqfWl9pTttvxE0p/9zZlcC/tpAQTOVFK6MmBBU/CGGaokRtl04wd8Pq7UIz8w/Dl8Fe0IbmmOwL1P+Vqg==}
+  '@vibe-agent-toolkit/discovery@0.1.26':
+    resolution: {integrity: sha512-nwWbNhFplxuk4y7MmV3++1f0AFqoiX2DxAqY5fGGWUGw9JTNm523VqzvbitzP4vVs4hI4KXySP7LTgYnNodH3w==}
 
-  '@vibe-agent-toolkit/gateway-mcp@0.1.22':
-    resolution: {integrity: sha512-BNUrNyueNzvSbZfEZVCKOVji60Pa2beNZo501HZgGk+c7y7SgtkX6ZInFHpf5ws9uwCXozshzrQSVnNHkPBvpg==}
+  '@vibe-agent-toolkit/gateway-mcp@0.1.26':
+    resolution: {integrity: sha512-XyqthuYpUrMog67LyLMl4ALL0WQCoAt90mwzsmx3+ig73nVhEcJtBJCCZPQqo76ETB+PcDMTxIS7A7KhS9iiPw==}
 
-  '@vibe-agent-toolkit/rag-lancedb@0.1.22':
-    resolution: {integrity: sha512-YysdDymbNlA0q6uR9BJ+a/yA2MsULAKZM9+5GkwXkiLPDddOxPhID8ERYQqUiLK5OZY9ifBNs4RVKuKDhqi3OQ==}
+  '@vibe-agent-toolkit/rag-lancedb@0.1.26':
+    resolution: {integrity: sha512-1loVhB1Wl6305pjMrizD+x5NyyQcsIhH4yPJBCKV1a3HcyKD4EHTeCxLTm5KfdFKEtoeqD4/zeiJ4pTjKuzWag==}
 
-  '@vibe-agent-toolkit/rag@0.1.22':
-    resolution: {integrity: sha512-EStRqDWwSjD9PnXOdwzEAfo3vUdCorVngV+AzFKreQUw85Vxl/axEfGFUayLewlJs28nAvF0YRhiHBk/TTcBIg==}
+  '@vibe-agent-toolkit/rag@0.1.26':
+    resolution: {integrity: sha512-Gp4/giCF4qxE4iPZx74FJFdmikBMtVGBovv9Yiv+jXDBudisJ+XWhxXGQRkeP1y4y3AIur+efEV/pg76d+mi3g==}
 
-  '@vibe-agent-toolkit/resources@0.1.22':
-    resolution: {integrity: sha512-83YkeaLideUm1+Ggj06jP+MMmYaH69VKeHYQX8ZfnjLMhXbo5ewv8nWYE44IPgfY4sWwhz+RyE3R2AwUMcVmzQ==}
+  '@vibe-agent-toolkit/resources@0.1.26':
+    resolution: {integrity: sha512-g7eoKtD51bEFT/L3pPQpZPOSvioOnTFxPLc9L3X2h0eYGDW1LsSt8TCv5JqJ2rdvj2eq0wrS7gMVXN5ZnAUVsg==}
 
-  '@vibe-agent-toolkit/utils@0.1.22':
-    resolution: {integrity: sha512-8NGIAetVpMeihAa5B8rx9ZlbQLLD/K7FZ9cItIaJ5+Sii7HP0BO18xF0FhWGAJXhkZj5GXeMeX7www89C+aVeA==}
+  '@vibe-agent-toolkit/utils@0.1.26':
+    resolution: {integrity: sha512-wfI8bBhSU3Q3YNXdleeUl2RgonHtHp33MJYHtRdGRzuitWPWm/wYvYRBkt+G1UUGEnHuTSho6nKGcwzAUtic0A==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@vibe-agent-toolkit/vat-development-agents@0.1.22':
-    resolution: {integrity: sha512-6IHn8rC0XnTWYORZr0w5EnIMMnIcm0jCHbCxZX4aP7zIZcIxtHdVy/alIY2zKLU/oef7IvUNAFvJt/7ECldaMQ==}
+  '@vibe-agent-toolkit/vat-development-agents@0.1.26':
+    resolution: {integrity: sha512-PHJCcyH/ZMdLUJJsKkGDF/WL5s3jbyLmKwiTeRLkXpME6jXCxfzT/Sejs7f3bG0MY9AXJPj4b6iE9R0J6ZYWXA==}
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -1554,6 +1554,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   binaryextensions@6.11.0:
     resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
@@ -4005,8 +4006,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vibe-agent-toolkit@0.1.22:
-    resolution: {integrity: sha512-uiN9x02HG+C1yqtk/IMQFwc9OVakMPZaBstxSL7maJffNHV49KI5tYZcpbou6zjdVLDeE/GIUvv6GVHb70UL2w==}
+  vibe-agent-toolkit@0.1.26:
+    resolution: {integrity: sha512-jMR6z9qhbkgX75xeTcUho/Da466CoEQkfQrNWZLU0nEUDX7Z5e7O4Co/s56M15c+uiB7ZVr91OfXE1zPuNECJQ==}
     hasBin: true
 
   vite-node@2.1.9:
@@ -5033,25 +5034,25 @@ snapshots:
       '@typescript-eslint/types': 8.50.1
       eslint-visitor-keys: 4.2.1
 
-  '@vibe-agent-toolkit/agent-config@0.1.22(zod@3.25.76)':
+  '@vibe-agent-toolkit/agent-config@0.1.26(zod@3.25.76)':
     dependencies:
-      '@vibe-agent-toolkit/agent-schema': 0.1.22
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.26
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       yaml: 2.8.2
     transitivePeerDependencies:
       - zod
 
-  '@vibe-agent-toolkit/agent-schema@0.1.22':
+  '@vibe-agent-toolkit/agent-schema@0.1.26':
     dependencies:
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
 
-  '@vibe-agent-toolkit/agent-skills@0.1.22':
+  '@vibe-agent-toolkit/agent-skills@0.1.26':
     dependencies:
-      '@vibe-agent-toolkit/agent-config': 0.1.22(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-schema': 0.1.22
-      '@vibe-agent-toolkit/resources': 0.1.22
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-config': 0.1.26(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.26
+      '@vibe-agent-toolkit/resources': 0.1.26
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       adm-zip: 0.5.16
       picomatch: 4.0.3
       yaml: 2.8.2
@@ -5060,26 +5061,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vibe-agent-toolkit/claude-marketplace@0.1.22':
+  '@vibe-agent-toolkit/claude-marketplace@0.1.26':
     dependencies:
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       ignore: 6.0.2
       yaml: 2.8.2
       zod: 3.25.76
 
-  '@vibe-agent-toolkit/cli@0.1.22':
+  '@vibe-agent-toolkit/cli@0.1.26':
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-config': 0.1.22(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-schema': 0.1.22
-      '@vibe-agent-toolkit/agent-skills': 0.1.22
-      '@vibe-agent-toolkit/claude-marketplace': 0.1.22
-      '@vibe-agent-toolkit/discovery': 0.1.22(zod@3.25.76)
-      '@vibe-agent-toolkit/gateway-mcp': 0.1.22
-      '@vibe-agent-toolkit/rag': 0.1.22
-      '@vibe-agent-toolkit/rag-lancedb': 0.1.22
-      '@vibe-agent-toolkit/resources': 0.1.22
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-config': 0.1.26(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.26
+      '@vibe-agent-toolkit/agent-skills': 0.1.26
+      '@vibe-agent-toolkit/claude-marketplace': 0.1.26
+      '@vibe-agent-toolkit/discovery': 0.1.26(zod@3.25.76)
+      '@vibe-agent-toolkit/gateway-mcp': 0.1.26
+      '@vibe-agent-toolkit/rag': 0.1.26
+      '@vibe-agent-toolkit/rag-lancedb': 0.1.26
+      '@vibe-agent-toolkit/resources': 0.1.26
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       adm-zip: 0.5.16
       commander: 12.1.0
       js-yaml: 4.1.1
@@ -5095,28 +5096,28 @@ snapshots:
       - supports-color
       - ws
 
-  '@vibe-agent-toolkit/discovery@0.1.22(zod@3.25.76)':
+  '@vibe-agent-toolkit/discovery@0.1.26(zod@3.25.76)':
     dependencies:
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       picomatch: 4.0.3
     transitivePeerDependencies:
       - zod
 
-  '@vibe-agent-toolkit/gateway-mcp@0.1.22':
+  '@vibe-agent-toolkit/gateway-mcp@0.1.26':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-schema': 0.1.22
+      '@vibe-agent-toolkit/agent-schema': 0.1.26
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@vibe-agent-toolkit/rag-lancedb@0.1.22':
+  '@vibe-agent-toolkit/rag-lancedb@0.1.26':
     dependencies:
       '@lancedb/lancedb': 0.23.0(apache-arrow@18.1.0)
-      '@vibe-agent-toolkit/rag': 0.1.22
-      '@vibe-agent-toolkit/resources': 0.1.22
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/rag': 0.1.26
+      '@vibe-agent-toolkit/resources': 0.1.26
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       apache-arrow: 18.1.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -5126,10 +5127,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@vibe-agent-toolkit/rag@0.1.22':
+  '@vibe-agent-toolkit/rag@0.1.26':
     dependencies:
-      '@vibe-agent-toolkit/resources': 0.1.22
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/resources': 0.1.26
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       gpt-tokenizer: 2.9.0
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
@@ -5144,10 +5145,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@vibe-agent-toolkit/resources@0.1.22':
+  '@vibe-agent-toolkit/resources@0.1.26':
     dependencies:
-      '@vibe-agent-toolkit/agent-schema': 0.1.22
-      '@vibe-agent-toolkit/utils': 0.1.22(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.26
+      '@vibe-agent-toolkit/utils': 0.1.26(zod@3.25.76)
       ajv: 8.17.1
       github-slugger: 2.0.0
       js-yaml: 4.1.1
@@ -5162,7 +5163,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vibe-agent-toolkit/utils@0.1.22(zod@3.25.76)':
+  '@vibe-agent-toolkit/utils@0.1.26(zod@3.25.76)':
     dependencies:
       handlebars: 4.7.9
       ignore: 7.0.5
@@ -5170,10 +5171,10 @@ snapshots:
       which: 5.0.0
       zod: 3.25.76
 
-  '@vibe-agent-toolkit/vat-development-agents@0.1.22':
+  '@vibe-agent-toolkit/vat-development-agents@0.1.26':
     dependencies:
-      '@vibe-agent-toolkit/agent-schema': 0.1.22
-      '@vibe-agent-toolkit/cli': 0.1.22
+      '@vibe-agent-toolkit/agent-schema': 0.1.26
+      '@vibe-agent-toolkit/cli': 0.1.26
       yaml: 2.8.2
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -8601,10 +8602,10 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vibe-agent-toolkit@0.1.22:
+  vibe-agent-toolkit@0.1.26:
     dependencies:
-      '@vibe-agent-toolkit/cli': 0.1.22
-      '@vibe-agent-toolkit/vat-development-agents': 0.1.22
+      '@vibe-agent-toolkit/cli': 0.1.26
+      '@vibe-agent-toolkit/vat-development-agents': 0.1.26
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - bare-abort-controller


### PR DESCRIPTION
## Summary

- Add Claude marketplace distribution alongside existing npm channel — users can install via `claude plugin marketplace add jdutton/vibe-validate#claude-marketplace`
- Add marketplace publish step to CI workflow (stable → `claude-marketplace`, RC → `claude-marketplace-next`)
- Update vibe-agent-toolkit dependency to ^0.1.26 for marketplace publish support
- Add custom marketplace README, root CHANGELOG reference, and MIT license to publish config

## Test plan

- [x] `vat build` succeeds locally
- [x] `vat claude marketplace publish --dry-run` works
- [x] `vat claude marketplace publish` creates `claude-marketplace` branch
- [x] `claude plugin marketplace add jdutton/vibe-validate#claude-marketplace` installs successfully
- [x] CI publish workflow passes with marketplace step (tested via v0.19.2-rc.4)
- [x] `claude-marketplace-next` branch created by CI with custom README
- [x] `pnpm validate` passes

🤖 Generated with [Claude Code](https://claude.ai/code)