### PR TITLE
fix: Always publish claude-marketplace-next on every release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,15 +62,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Publish Claude marketplace
+      - name: Publish Claude marketplace (next)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ steps.version_type.outputs.is_stable }}" = "true" ]; then
-            pnpm --filter vibe-validate exec vat claude marketplace publish
-          else
-            pnpm --filter vibe-validate exec vat claude marketplace publish --branch claude-marketplace-next
-          fi
+        run: pnpm --filter vibe-validate exec vat claude marketplace publish --branch claude-marketplace-next
+
+      - name: Publish Claude marketplace (stable)
+        if: steps.version_type.outputs.is_stable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter vibe-validate exec vat claude marketplace publish
 
       - name: Extract CHANGELOG for release (stable only)
         if: steps.version_type.outputs.is_stable == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ pnpm-debug.log*
 TODO.md
 TODO*.md
 docs/plans/
+docs/superpowers/
 .worktrees/
 
 # At this point, top level markdown files are usually status, summary, or undesirable artifacts from agentic coding tools, so ignore all top-level *.md files that don't already exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-04-11
+
 ### Fixed
 
 - **Claude marketplace CI** — Stable releases now update both `claude-marketplace` and `claude-marketplace-next` branches, matching npm's `@latest`/`@next` tag behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Claude marketplace CI** — Stable releases now update both `claude-marketplace` and `claude-marketplace-next` branches, matching npm's `@latest`/`@next` tag behavior
+
+### Changed
+
+- **README** — Added Claude Code plugin install instructions (marketplace, `/plugin` slash command, project-scope)
+
 ## [0.19.2] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -269,6 +269,40 @@ vibe-validate includes 14+ built-in extractors that parse verbose output from po
 
 ---
 
+## Claude Code Plugin
+
+vibe-validate ships a [Claude Code](https://claude.ai/code) skill that teaches Claude how to configure and use vibe-validate in your projects. The skill is published via [vibe-agent-toolkit](https://github.com/jdutton/vibe-agent-toolkit).
+
+### Install from the [Claude marketplace](https://github.com/jdutton/vibe-validate/tree/claude-marketplace) (no npm required)
+
+```bash
+claude plugin marketplace add jdutton/vibe-validate#claude-marketplace
+claude plugin install vibe-validate@vibe-validate
+```
+
+Or from within a Claude Code session:
+
+```
+/plugin marketplace add jdutton/vibe-validate#claude-marketplace
+/plugin install vibe-validate@vibe-validate
+```
+
+**For project-scope** (shared with team via `.claude/settings.json`), add `--scope project`:
+
+```bash
+claude plugin marketplace add jdutton/vibe-validate#claude-marketplace --scope project
+```
+
+### Install via npm (automatic)
+
+```bash
+npm install -g vibe-validate
+```
+
+The npm package includes a postinstall hook that registers the plugin automatically.
+
+---
+
 ## Related Tools
 
 vibe-validate complements build optimization tools like Turborepo:

--- a/docs/marketplace-readme.md
+++ b/docs/marketplace-readme.md
@@ -6,22 +6,28 @@ LLM-optimized validation orchestration for vibe coding. [vibe-validate](https://
 
 ## Install
 
-### For yourself (user-level)
+### From the terminal
 
 ```bash
 claude plugin marketplace add jdutton/vibe-validate#claude-marketplace
 claude plugin install vibe-validate@vibe-validate
 ```
 
+### From within Claude Code
+
+```
+/plugin marketplace add jdutton/vibe-validate#claude-marketplace
+/plugin install vibe-validate@vibe-validate
+```
+
 ### For your project (shared with team)
+
+Add `--scope project` to write to `.claude/settings.json` (committed to git). Team members who clone the repo will be prompted to install the marketplace automatically.
 
 ```bash
 claude plugin marketplace add jdutton/vibe-validate#claude-marketplace --scope project
 claude plugin install vibe-validate@vibe-validate
 ```
-
-Project-scope writes to `.claude/settings.json` (committed to git). Team members
-who clone the repo will be prompted to install the marketplace automatically.
 
 ### Update
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.3-rc.1'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.3'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.2'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.3-rc.1'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.2 # Tracks vibe-validate package version
+version: 0.19.3-rc.1 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.3-rc.1 # Tracks vibe-validate package version
+version: 0.19.3 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.2",
+  "version": "0.19.3-rc.1",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.3-rc.1",
+  "version": "0.19.3",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Always publish `claude-marketplace-next` on every release (both RC and stable), matching npm's `@latest`/`@next` tag behavior
- Add Claude Code plugin install instructions to main README — marketplace, `/plugin` slash command, `--scope project`, and link to [vibe-agent-toolkit](https://github.com/jdutton/vibe-agent-toolkit)
- Add `/plugin` slash command and terminal install options to marketplace README
- Gitignore `docs/superpowers/` (new default plan location)

## Test plan

- [ ] Next RC or stable release should update both marketplace branches
- [x] README instructions are accurate for both terminal and in-session install
- [x] `pnpm validate` passes

🤖 Generated with [Claude Code](https://claude.ai/code)