### PR TITLE
fix(dev-tools): add pre-release checks, auto-stamp CHANGELOG, prevent failed releases

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -137,18 +137,18 @@
       "mcp__github__get_pull_request_status",
       "mcp__github__list_issues"
     ],
-    "ask": [
-      "Bash(gh run list *)",
-      "Bash(gh run view *)",
-      "Bash(git commit *)",
-      "Bash(*jscpd-update-baseline*)"
-    ],
     "deny": [
       "Skill(superpowers:using-git-worktrees)",
       "Bash(sed *)",
       "Bash(sed)",
       "Bash(awk *)",
       "Bash(awk)"
+    ],
+    "ask": [
+      "Bash(gh run list *)",
+      "Bash(gh run view *)",
+      "Bash(git commit *)",
+      "Bash(*jscpd-update-baseline*)"
     ]
   },
   "hooks": {
@@ -164,5 +164,24 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "vibe-validate@vibe-validate": true
+  },
+  "extraKnownMarketplaces": {
+    "vibe-validate": {
+      "source": {
+        "source": "github",
+        "repo": "jdutton/vibe-validate",
+        "ref": "claude-marketplace"
+      }
+    },
+    "vat-skills": {
+      "source": {
+        "source": "github",
+        "repo": "jdutton/vibe-agent-toolkit",
+        "ref": "claude-marketplace"
+      }
+    }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,20 +138,23 @@ Updates all package.json files + Claude Code plugin manifest.
 **Automated via GitHub Actions**. DO NOT use `pnpm publish:all` manually unless automation fails.
 
 ### Full Release (e.g., v0.19.0)
-1. Update CHANGELOG.md: Change `[Unreleased]` → `[0.19.0] - YYYY-MM-DD`
-2. `pnpm bump-version 0.19.0`
-3. `git commit -m "chore: Release v0.19.0"`
-4. `git tag v0.19.0 && git push origin main v0.19.0`
-5. Monitor: https://github.com/jdutton/vibe-validate/actions
+1. `pnpm bump-version 0.19.0` (validates CHANGELOG, auto-stamps `[Unreleased]` → `[0.19.0] - YYYY-MM-DD`)
+2. `git commit -m "chore: Release v0.19.0"`
+3. Merge to main, then run: `pnpm pre-release` (validates tag doesn't exist, CHANGELOG section non-empty)
+4. Only after pre-release passes: `git tag v0.19.0`
+5. `git push origin main v0.19.0`
+6. Monitor: https://github.com/jdutton/vibe-validate/actions
+
+**Do NOT tag until `pnpm pre-release` passes. Tags trigger CI publish.**
 
 ### Pre-Release (e.g., v0.19.0-rc.2)
 1. **DO NOT update CHANGELOG.md** - keep changes under `[Unreleased]`
-2. `pnpm bump-version 0.19.0-rc.2`
+2. `pnpm bump-version 0.19.0-rc.2` (skips CHANGELOG stamp for pre-releases)
 3. `git commit -m "chore: Prepare v0.19.0-rc.2"`
 4. `git tag v0.19.0-rc.2 && git push origin main v0.19.0-rc.2`
 5. Monitor: https://github.com/jdutton/vibe-validate/actions
 
-**IMPORTANT**: CHANGELOG `[Unreleased]` → `[X.Y.Z]` updates are ONLY for full releases, NEVER for pre-releases (rc, beta, alpha).
+**IMPORTANT**: CHANGELOG `[Unreleased]` → `[X.Y.Z]` updates are ONLY for full releases, NEVER for pre-releases (rc, beta, alpha). The `bump-version` script enforces this automatically.
 
 See `docs/automated-publishing.md` for RC vs stable behavior, troubleshooting.
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "generate-cli-docs": "tsx packages/dev-tools/src/generate-cli-docs.ts",
     "bump-version": "tsx packages/dev-tools/src/bump-version.ts",
     "pre-publish": "tsx packages/dev-tools/src/pre-publish-check.ts",
+    "pre-release": "tsx packages/dev-tools/src/pre-publish-check.ts --release-readiness",
     "verify-npm-packages": "tsx packages/dev-tools/src/verify-npm-packages.ts",
     "publish:dry-run": "pnpm -r --filter='@vibe-validate/*' exec npm publish --dry-run",
     "publish:all": "tsx packages/dev-tools/src/publish-all.ts \"$@\"",

--- a/packages/dev-tools/src/bump-version.ts
+++ b/packages/dev-tools/src/bump-version.ts
@@ -21,11 +21,36 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
+import semver from 'semver';
+
 import { PROJECT_ROOT, log, processWorkspacePackages } from './common.js';
 
 // Constants for duplicate string elimination
 const PACKAGE_JSON_FILENAME = 'package.json';
 const VIBE_VALIDATE_PKG_NAME = 'vibe-validate';
+const CHANGELOG_PATH = join(PROJECT_ROOT, 'CHANGELOG.md');
+const UNRELEASED_HEADING = '## [Unreleased]';
+
+interface ChangelogUnreleasedSection {
+  content: string;
+  body: string;
+  unreleasedIndex: number;
+  afterHeading: number;
+  nextSectionOffset: number;
+}
+
+function parseChangelogUnreleased(): ChangelogUnreleasedSection {
+  const content = readFileSync(CHANGELOG_PATH, 'utf8');
+  const unreleasedIndex = content.indexOf(UNRELEASED_HEADING);
+  if (unreleasedIndex === -1) {
+    throw new Error('CHANGELOG.md is missing the [Unreleased] section');
+  }
+  const afterHeading = unreleasedIndex + UNRELEASED_HEADING.length;
+  const nextSectionMatch = /\n## \[/.exec(content.slice(afterHeading));
+  const nextSectionOffset = nextSectionMatch?.index ?? content.slice(afterHeading).length;
+  const body = content.slice(afterHeading, afterHeading + nextSectionOffset);
+  return { content, body, unreleasedIndex, afterHeading, nextSectionOffset };
+}
 
 // Helper to log file processing errors with proper error type handling
 function logFileError(fileName: string, error: unknown): void {
@@ -119,12 +144,40 @@ if (['patch', 'minor', 'major'].includes(versionArg)) {
   // Explicit version provided
   newVersion = versionArg;
 
-  // Validate version format (simple semver check)
-  // eslint-disable-next-line security/detect-unsafe-regex -- Simple semver pattern, safe
-  if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
+  // Validate version format using semver
+  if (!semver.valid(newVersion)) {
     log(`✗ Invalid version format: ${newVersion}`, 'red');
     log('  Expected format: X.Y.Z or X.Y.Z-prerelease', 'yellow');
     log('  Examples: 0.14.2, 1.0.0, 1.0.0-beta.1, patch, minor, major', 'yellow');
+    process.exit(1);
+  }
+}
+
+// Pre-flight: validate CHANGELOG before touching any files (prevents dirty state on failure)
+const isPrerelease = semver.prerelease(newVersion) !== null;
+if (!isPrerelease) {
+  try {
+    const { content, body } = parseChangelogUnreleased();
+
+    // Safety: refuse to stamp if this version already exists in CHANGELOG
+    const escapedVersion = newVersion.replaceAll('.', String.raw`\.`);
+    // eslint-disable-next-line security/detect-non-literal-regexp -- version is from CLI arg, already validated by semver
+    const existingPattern = new RegExp(String.raw`^## \[${escapedVersion}\]`, 'm');
+    if (existingPattern.test(content)) {
+      log(`✗ CHANGELOG.md already has an entry for [${newVersion}]. Refusing to stamp to avoid corruption.`, 'red');
+      console.log('  If you need to re-stamp, manually remove the existing entry first.');
+      process.exit(1);
+    }
+
+    if (!body.trim()) {
+      log('✗ CHANGELOG.md has no content under [Unreleased]. Add release notes before bumping to a stable version.', 'red');
+      process.exit(1);
+    }
+
+    log('✓ CHANGELOG.md pre-flight check passed', 'green');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`✗ Failed to validate CHANGELOG.md: ${message}`, 'red');
     process.exit(1);
   }
 }
@@ -313,6 +366,28 @@ try {
   skillSkippedCount++;
 }
 
+// Stamp CHANGELOG.md for stable releases (pre-flight already validated, just do the write)
+if (isPrerelease) {
+  log('⊘ CHANGELOG stamp skipped (prerelease version)', 'yellow');
+} else {
+  try {
+    const { content, body, afterHeading, nextSectionOffset } = parseChangelogUnreleased();
+    const today = new Date().toISOString().split('T')[0] ?? '';
+    const versionHeading = `## [${newVersion}] - ${today}`;
+
+    const before = content.slice(0, afterHeading);
+    const after = content.slice(afterHeading + nextSectionOffset);
+    const updatedChangelog = `${before}\n\n${versionHeading}\n${body.replace(/^\n/, '')}${after}`;
+
+    writeFileSync(CHANGELOG_PATH, updatedChangelog, 'utf8');
+    log(`✓ CHANGELOG.md stamped for v${newVersion}`, 'green');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`✗ Failed to stamp CHANGELOG.md: ${message}`, 'red');
+    process.exit(1);
+  }
+}
+
 console.log('');
 log(`✅ Version bump complete!`, 'green');
 log(`   Packages updated: ${updatedCount + (updatedCount > 0 || skippedCount === 0 ? 1 : 0)}`, 'green');
@@ -324,9 +399,17 @@ if (skippedCount > 0 || testSkippedCount > 0 || skillSkippedCount > 0) {
 console.log('');
 console.log('Next steps:');
 console.log(`  1. Review changes: git diff`);
-console.log(`  2. Commit: git add -A && git commit -m "chore: Release v${newVersion}"`);
-console.log(`  3. Tag: git tag v${newVersion}`);
-console.log(`  4. Push: git push origin main && git push origin v${newVersion}`);
+console.log(`  2. Commit: git add -A && git commit -m "chore: bump version to v${newVersion}"`);
+if (isPrerelease) {
+  console.log(`  3. Push: git push origin main`);
+  console.log(`  (RC versions are not tagged — content stays under [Unreleased] in CHANGELOG)`);
+} else {
+  console.log(`  3. Merge to main, then run: pnpm pre-release`);
+  console.log(`  4. Only after pre-release passes: git tag v${newVersion}`);
+  console.log(`  5. Push: git push origin main v${newVersion}`);
+  console.log('');
+  log('⚠ Do NOT tag until pnpm pre-release passes. Tags trigger CI publish.', 'yellow');
+}
 console.log('');
 
 process.exit(0);

--- a/packages/dev-tools/src/pre-publish-check.ts
+++ b/packages/dev-tools/src/pre-publish-check.ts
@@ -13,11 +13,16 @@
  * 8. Workspace dependencies are correct
  * 9. All packages have proper "files" field
  * 10. All packages have required metadata (repository, author, license)
- * 11. CHANGELOG.md has entry for current version (publish mode only)
+ * 11. CHANGELOG.md has entry for current version
+ *
+ * Release-readiness checks (--release-readiness only):
+ * 12. Tag doesn't already exist on remote
+ * 13. No stale unreleased content (stable versions only)
+ * 14. CHANGELOG section non-empty (stable versions only)
  *
  * Usage:
- *   tsx packages/dev-tools/src/pre-publish-check.ts [--allow-branch BRANCH] [--skip-git-checks]
- *   pnpm pre-publish [--allow-branch BRANCH] [--skip-git-checks]
+ *   tsx packages/dev-tools/src/pre-publish-check.ts [--allow-branch BRANCH] [--skip-git-checks] [--release-readiness]
+ *   pnpm pre-publish [--allow-branch BRANCH] [--skip-git-checks] [--release-readiness]
  *
  * Exit codes:
  *   0 - Ready to publish
@@ -84,6 +89,7 @@ const args = process.argv.slice(2);
 let allowedBranch = 'main';
 let allowCustomBranch = false;
 let skipGitChecks = false;
+let releaseReadiness = false;
 
 let i = 0;
 while (i < args.length) {
@@ -92,9 +98,11 @@ while (i < args.length) {
     allowedBranch = nextArg;
     allowCustomBranch = true;
     i += 2;
+    continue;
   } else if (args[i] === '--skip-git-checks') {
     skipGitChecks = true;
-    i += 1;
+  } else if (args[i] === '--release-readiness') {
+    releaseReadiness = true;
   } else if (args[i] === '--help' || args[i] === '-h') {
     console.log(`
 Pre-Publish Validation Check
@@ -107,6 +115,10 @@ Options:
   --allow-branch BRANCH  Allow publishing from a specific branch (default: main)
   --skip-git-checks      Skip git-related checks (branch, uncommitted changes, untracked files)
                          Use this when running in vibe-validate during development
+  --release-readiness    Run additional release-readiness checks:
+                           - Tag doesn't already exist on remote
+                           - No stale unreleased content
+                           - CHANGELOG section non-empty
   --help, -h             Show this help message
 
 Exit codes:
@@ -532,79 +544,168 @@ try {
   process.exit(1);
 }
 
-// Check 11: CHANGELOG.md has entry for current version (skip in development mode)
-if (skipGitChecks) {
-  log('⊘ CHANGELOG check skipped (development mode)', 'yellow');
-} else {
-  console.log('');
-  console.log('Checking CHANGELOG.md...');
+// Check 11: CHANGELOG.md has entry for current version (content check, always runs)
+console.log('');
+console.log('Checking CHANGELOG.md...');
 
-  try {
-    // Read version from umbrella package (monorepo canonical version)
-    const umbrellaPkgJsonPath = join(packagesDir, 'vibe-validate', 'package.json');
-    if (!existsSync(umbrellaPkgJsonPath)) {
-      throw new Error('Umbrella package (vibe-validate) package.json not found');
-    }
+// Read version from umbrella package (monorepo canonical version) — hoisted for use by release-readiness checks
+let currentVersion: string;
+try {
+  const umbrellaPkgJsonPath = join(packagesDir, 'vibe-validate', 'package.json');
+  if (!existsSync(umbrellaPkgJsonPath)) {
+    throw new Error('Umbrella package (vibe-validate) package.json not found');
+  }
 
-    const umbrellaPkgJson = JSON.parse(readFileSync(umbrellaPkgJsonPath, 'utf8')) as Record<string, unknown>;
-    const version = umbrellaPkgJson['version'];
-    if (typeof version !== 'string') {
-      throw new TypeError('Version not found in umbrella package (vibe-validate) package.json');
-    }
+  const umbrellaPkgJson = JSON.parse(readFileSync(umbrellaPkgJsonPath, 'utf8')) as Record<string, unknown>;
+  const version = umbrellaPkgJson['version'];
+  if (typeof version !== 'string') {
+    throw new TypeError('Version not found in umbrella package (vibe-validate) package.json');
+  }
+  currentVersion = version;
+} catch (error) {
+  log('✗ Failed to read version from umbrella package', 'red');
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}
 
-    // Read CHANGELOG.md
-    const changelogPath = join(PROJECT_ROOT, 'CHANGELOG.md');
-    if (!existsSync(changelogPath)) {
-      log('✗ CHANGELOG.md not found', 'red');
-      console.log('  Create CHANGELOG.md to document releases');
+try {
+  // Read CHANGELOG.md
+  const changelogPath = join(PROJECT_ROOT, 'CHANGELOG.md');
+  if (!existsSync(changelogPath)) {
+    log('✗ CHANGELOG.md not found', 'red');
+    console.log('  Create CHANGELOG.md to document releases');
+    process.exit(1);
+  }
+
+  // Skip CHANGELOG check for prerelease versions (RC, alpha, beta, etc.)
+  const isPrerelease = /-(rc|alpha|beta|dev|canary)\./i.test(currentVersion);
+  if (isPrerelease) {
+    log(`⊘ CHANGELOG check skipped (prerelease version: ${currentVersion})`, 'yellow');
+  } else {
+    const changelogContent = readFileSync(changelogPath, 'utf8');
+
+    // Look for version entry: ## [X.Y.Z] - YYYY-MM-DD
+    // Escape dots in version string for regex matching
+    const escapedVersion = currentVersion.replaceAll('.', String.raw`\.`);
+    // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
+    const versionPattern = new RegExp(String.raw`^## \[${escapedVersion}\] - \d{4}-\d{2}-\d{2}`, 'm');
+
+    if (!versionPattern.test(changelogContent)) {
+      log(`✗ CHANGELOG.md missing entry for version ${currentVersion}`, 'red');
+      console.log('');
+      console.log('  Recovery instructions:');
+      console.log(`  1. Add version entry to CHANGELOG.md:`);
+      console.log(`     ## [${currentVersion}] - ${String(new Date().toISOString().split('T')[0] ?? '')}`);
+      console.log('  2. Document changes under the version header');
+      console.log('  3. Run pre-publish-check again');
+      console.log('');
       process.exit(1);
     }
 
-    // Skip CHANGELOG check for prerelease versions (RC, alpha, beta, etc.)
-    const isPrerelease = /-(rc|alpha|beta|dev|canary)\./i.test(version);
-    if (isPrerelease) {
-      log(`⊘ CHANGELOG check skipped (prerelease version: ${version})`, 'yellow');
-    } else {
-      const changelogContent = readFileSync(changelogPath, 'utf8');
+    log(`✓ CHANGELOG.md has entry for version ${currentVersion}`, 'green');
+  }
+} catch (error) {
+  log('✗ Failed to check CHANGELOG.md', 'red');
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}
 
-      // Look for version entry: ## [X.Y.Z] - YYYY-MM-DD
-      // Escape dots in version string for regex matching
-      const escapedVersion = version.replaceAll('.', String.raw`\.`);
+// Release-readiness checks (only when --release-readiness is passed)
+if (releaseReadiness) {
+  console.log('');
+  console.log('Running release-readiness checks...');
+
+  // Check 12: Tag doesn't already exist on remote
+  console.log('');
+  console.log(`Checking remote tag v${currentVersion}...`);
+
+  {
+    const tagResult = executeGitCommand(['ls-remote', '--tags', 'origin', `refs/tags/v${currentVersion}`], {
+      encoding: 'utf8',
+      ignoreErrors: true,
+    });
+
+    if (tagResult.success && tagResult.stdout.trim().length > 0) {
+      log(`✗ v${currentVersion} tag already exists on remote`, 'red');
+      console.log(`  The tag v${currentVersion} has already been pushed to the remote.`);
+      console.log('  Bump the version before releasing.');
+      process.exit(1);
+    }
+
+    log(`✓ v${currentVersion} tag does not exist on remote`, 'green');
+  }
+
+  // Check 13 & 14: CHANGELOG content checks (stable versions only)
+  const isPrerelease = /-(rc|alpha|beta|dev|canary)\./i.test(currentVersion);
+  if (isPrerelease) {
+    log(`⊘ CHANGELOG content checks skipped (prerelease version: ${currentVersion})`, 'yellow');
+  } else {
+    const changelogPath = join(PROJECT_ROOT, 'CHANGELOG.md');
+    const changelogContent = readFileSync(changelogPath, 'utf8');
+
+    // Check 13: No stale unreleased content
+    console.log('');
+    console.log('Checking for stale unreleased content...');
+
+    {
+      const escapedVersion = currentVersion.replaceAll('.', String.raw`\.`);
       // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
-      const versionPattern = new RegExp(String.raw`^## \[${escapedVersion}\] - \d{4}-\d{2}-\d{2}`, 'm');
+      const versionPattern = new RegExp(String.raw`^## \[${escapedVersion}\]`, 'm');
+      const isStamped = versionPattern.test(changelogContent);
 
-      if (!versionPattern.test(changelogContent)) {
-        log(`✗ CHANGELOG.md missing entry for version ${version}`, 'red');
-        console.log('');
-        console.log('  Recovery instructions:');
-        console.log(`  1. Add version entry to CHANGELOG.md:`);
-        console.log(`     ## [${version}] - ${new Date().toISOString().split('T')[0]}`);
-        console.log('  2. Document changes under the version header');
-        console.log('  3. Run pre-publish-check again');
-        console.log('');
+      if (isStamped) {
+        // Check if [Unreleased] has content
+        const unreleasedMatch = /^## \[Unreleased\]([\s\S]*?)(?=^## \[|$)/m.exec(changelogContent);
+        const unreleasedContent = unreleasedMatch?.[1]?.trim() ?? '';
+        if (unreleasedContent.length > 0) {
+          log(`⚠ v${currentVersion} is stamped but not yet released. New changes should go under [${currentVersion}], not [Unreleased].`, 'yellow');
+        } else {
+          log('✓ No stale unreleased content', 'green');
+        }
+      } else {
+        log('✓ No stale unreleased content', 'green');
+      }
+    }
+
+    // Check 14: CHANGELOG section non-empty
+    console.log('');
+    console.log(`Checking CHANGELOG section for v${currentVersion} is non-empty...`);
+
+    {
+      const escapedVersion = currentVersion.replaceAll('.', String.raw`\.`);
+      // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
+      const sectionPattern = new RegExp(String.raw`^## \[${escapedVersion}\][^\n]*\n([\s\S]*?)(?=^## \[|\z)`, 'm');
+      const sectionMatch = sectionPattern.exec(changelogContent);
+      const sectionContent = sectionMatch?.[1]?.trim() ?? '';
+
+      if (sectionContent.length === 0) {
+        log(`✗ CHANGELOG section for v${currentVersion} is empty`, 'red');
+        console.log('  Add at least one entry under the version heading before releasing.');
         process.exit(1);
       }
 
-      log(`✓ CHANGELOG.md has entry for version ${version}`, 'green');
+      log(`✓ CHANGELOG section for v${currentVersion} has content`, 'green');
     }
-  } catch (error) {
-    log('✗ Failed to check CHANGELOG.md', 'red');
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exit(1);
   }
 }
 
 // Success!
 console.log('');
-log('✅ Repository is ready to publish!', 'green');
-console.log('');
-console.log('Next steps:');
-console.log('  1. Update package versions: pnpm bump-version patch (or minor/major)');
-console.log('  2. Commit version changes: git commit -am \'chore: Release vX.Y.Z\'');
-console.log('  3. Create git tag: git tag -a vX.Y.Z -m \'Release vX.Y.Z\'');
-console.log('  4. Push to GitHub: git push origin main --tags');
-console.log('  5. GitHub Actions will automatically publish to npm');
+if (releaseReadiness) {
+  log(`✅ Release v${currentVersion} is ready! Safe to tag and push.`, 'green');
+  console.log('');
+  console.log('Next steps:');
+  console.log(`  1. Tag:  git tag v${currentVersion}`);
+  console.log(`  2. Push: git push origin main v${currentVersion}`);
+  console.log('');
+  console.log('CI will publish to npm and create the GitHub release automatically.');
+} else {
+  log('✅ Validation checks passed.', 'green');
+  console.log('');
+  console.log('Before tagging a release, run: pnpm pre-release');
+}
 console.log('');
 
 process.exit(0);


### PR DESCRIPTION
## Summary

Ports release safety improvements from vibe-agent-toolkit (#78) to vibe-validate:

- **bump-version pre-flight** — validates CHANGELOG before touching any files (prevents dirty repo state on failure). Refuses if version already exists or `[Unreleased]` is empty. Auto-stamps CHANGELOG for stable releases, skips for pre-releases.
- **pre-publish-check** — moved CHANGELOG check out of `--skip-git-checks` gate (it's a content check, not a git check). Added `--release-readiness` flag with tag existence, stale unreleased content, and section non-empty checks. Fixed `--allow-branch` arg parsing bug (missing `continue`).
- **`pnpm pre-release` script** — new pre-tag validation gate that runs `pre-publish-check --release-readiness`
- **CLAUDE.md** — updated release workflow to enforce `pnpm pre-release` before tagging

## Test plan

- [x] `pnpm validate` passes (all 8 steps, both phases)
- [ ] Manual: `pnpm bump-version 99.99.99` should auto-stamp CHANGELOG and show new "Next steps" output
- [ ] Manual: `pnpm bump-version 99.99.99-rc.1` should skip CHANGELOG stamp and show RC-specific output
- [ ] Manual: `pnpm pre-release` should run release-readiness checks (tag existence, CHANGELOG content)

🤖 Generated with [Claude Code](https://claude.ai/code)