### PR TITLE
fix(watch-pr): --fail-fast exits on first extraction, not all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`watch-pr --fail-fast`** — Now exits on first failure extraction instead of waiting for all failures, matching the documented "exit immediately" behavior
+
 ## [0.19.3] - 2026-04-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/watch-pr.ts
+++ b/packages/cli/src/commands/watch-pr.ts
@@ -6,6 +6,7 @@ import { stringify as stringifyYaml } from 'yaml';
 import type { WatchPRResult } from '../schemas/watch-pr-result.schema.js';
 import { WatchPROrchestrator } from '../services/watch-pr-orchestrator.js';
 import { getCommandName } from '../utils/command-name.js';
+import { allFailedChecksHaveExtraction, anyFailedCheckHasExtraction } from '../utils/watch-pr-exit-conditions.js';
 
 interface WatchPROptions {
   yaml?: boolean;
@@ -154,30 +155,6 @@ function checkTimeout(startTime: number, timeoutMs: number, previousResult: Watc
 }
 
 /**
- * Check if all failed checks have extraction or log_file
- *
- * When checks fail, we want to wait for log extraction to complete before
- * exiting polling. This handles the GitHub API race condition where logs
- * aren't immediately available when a check completes.
- *
- * @param result - Current result
- * @returns True if all failed checks have extraction or log_file
- */
-function allFailedChecksHaveExtraction(result: WatchPRResult): boolean {
-  const failedActions = result.checks.github_actions.filter(c => c.conclusion === 'failure');
-  const failedExternal = result.checks.external_checks.filter(c => c.conclusion === 'failure');
-
-  // All failed GitHub Actions must have extraction OR log_file
-  // Use Boolean() to satisfy eslint prefer-nullish-coalescing rule
-  const actionsComplete = failedActions.every(c => Boolean(c.extraction) || Boolean(c.log_file));
-
-  // External checks don't have log extraction, so just check they're complete
-  const externalComplete = failedExternal.every(c => c.status === 'completed');
-
-  return actionsComplete && externalComplete;
-}
-
-/**
  * Check exit conditions (fail-fast or completion)
  *
  * @param result - Current result
@@ -190,11 +167,11 @@ function checkExitConditions(
   orchestrator: WatchPROrchestrator,
   options: WatchPROptions
 ): number | null {
-  // Check if should fail fast (but only if extraction is complete)
+  // Check if should fail fast (exit once ANY failure has extraction ready)
   if (options.failFast && result.status === 'failed') {
-    // Wait for first failure to have extraction before exiting
-    if (!allFailedChecksHaveExtraction(result)) {
-      return null; // Continue polling to get extraction
+    // Only need one failure's extraction to provide useful output
+    if (!anyFailedCheckHasExtraction(result)) {
+      return null; // Continue polling until at least one extraction is ready
     }
     process.stdout.write('\n⚡ Failing fast (--fail-fast enabled)\n\n');
     process.stdout.write('---\n');

--- a/packages/cli/src/utils/watch-pr-exit-conditions.ts
+++ b/packages/cli/src/utils/watch-pr-exit-conditions.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure exit-condition logic for watch-pr polling loop
+ *
+ * Extracted for testability — these functions determine when to stop polling.
+ *
+ * @packageDocumentation
+ */
+
+import type { WatchPRResult } from '../schemas/watch-pr-result.schema.js';
+
+/**
+ * Check if ALL failed checks have extraction or log_file
+ *
+ * Used in normal (non-fail-fast) mode to wait for complete error extraction
+ * before displaying final results.
+ *
+ * @param result - Current result
+ * @returns True if all failed checks have extraction or log_file
+ */
+export function allFailedChecksHaveExtraction(result: WatchPRResult): boolean {
+  const failedActions = result.checks.github_actions.filter(c => c.conclusion === 'failure');
+  const failedExternal = result.checks.external_checks.filter(c => c.conclusion === 'failure');
+
+  // All failed GitHub Actions must have extraction OR log_file
+  // Use Boolean() to satisfy eslint prefer-nullish-coalescing rule
+  const actionsComplete = failedActions.every(c => Boolean(c.extraction) || Boolean(c.log_file));
+
+  // External checks don't have log extraction, so just check they're complete
+  const externalComplete = failedExternal.every(c => c.status === 'completed');
+
+  return actionsComplete && externalComplete;
+}
+
+/**
+ * Check if ANY failed check has extraction or log_file
+ *
+ * Used in fail-fast mode — exit as soon as the first failure has its
+ * extraction ready, rather than waiting for all failures.
+ *
+ * @param result - Current result
+ * @returns True if at least one failed check has extraction or log_file
+ */
+export function anyFailedCheckHasExtraction(result: WatchPRResult): boolean {
+  const failedActions = result.checks.github_actions.filter(c => c.conclusion === 'failure');
+  const failedExternal = result.checks.external_checks.filter(c => c.conclusion === 'failure');
+
+  // Any failed GitHub Action with extraction OR log_file counts
+  const anyActionComplete = failedActions.some(c => Boolean(c.extraction) || Boolean(c.log_file));
+
+  // Any completed failed external check counts
+  const anyExternalComplete = failedExternal.some(c => c.status === 'completed');
+
+  // If there are no failed actions, external completions are enough (and vice versa)
+  if (failedActions.length === 0 && failedExternal.length === 0) return false;
+  if (failedActions.length === 0) return anyExternalComplete;
+  if (failedExternal.length === 0) return anyActionComplete;
+
+  return anyActionComplete || anyExternalComplete;
+}

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.3'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.4-rc.1'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.4-rc.1'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.4-rc.2'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/commands/watch-pr.test.ts
+++ b/packages/cli/test/commands/watch-pr.test.ts
@@ -479,22 +479,21 @@ describe('watch-pr command', () => {
   });
 
   describe('--fail-fast option', () => {
-    it('should exit immediately when any check fails (integration test - placeholder)', async () => {
-      // Full end-to-end test with --fail-fast requires comprehensive mocking
-      // Option is registered and wired up in the command
-      // Integration tests with real PRs verify this behavior
-      expect(true).toBe(true);
-    });
+    // Exit-condition logic (allFailedChecksHaveExtraction, anyFailedCheckHasExtraction)
+    // is unit tested in test/utils/watch-pr-exit-conditions.test.ts
 
-    it('should continue polling without --fail-fast', async () => {
-      // This is tested by the normal polling behavior tests
-      // Without --fail-fast, polling continues even when status is failed
-      expect(true).toBe(true);
-    });
+    it('should accept --fail-fast option without error', async () => {
+      const result = await executeVv([
+        'watch-pr',
+        '999999',
+        '--fail-fast',
+        '--timeout',
+        '1',
+      ]);
 
-    it('should not fail-fast on pending status', async () => {
-      // fail-fast only triggers on status='failed', not on pending with failures
-      expect(true).toBe(true);
+      // Should accept the option without argument validation error
+      expect(result.stderr).not.toContain('unknown option');
+      expect(result.stderr).not.toContain('--fail-fast');
     });
   });
 

--- a/packages/cli/test/utils/watch-pr-exit-conditions.test.ts
+++ b/packages/cli/test/utils/watch-pr-exit-conditions.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ExternalCheck, GitHubActionCheck, WatchPRResult } from '../../src/schemas/watch-pr-result.schema.js';
+import {
+  allFailedChecksHaveExtraction,
+  anyFailedCheckHasExtraction,
+} from '../../src/utils/watch-pr-exit-conditions.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/** Minimal PR metadata for tests */
+const basePR: WatchPRResult['pr'] = {
+  number: 1,
+  title: 'test',
+  url: 'https://github.com/test/test/pull/1',
+  branch: 'test',
+  base_branch: 'main',
+  author: 'test',
+  draft: false,
+  mergeable: true,
+  merge_state_status: 'CLEAN',
+  labels: [],
+};
+
+/** Create a failed GitHub Action check with optional extraction/log_file */
+function createFailedAction(
+  overrides: Partial<GitHubActionCheck> = {}
+): GitHubActionCheck {
+  return {
+    name: overrides.name ?? 'Test Job',
+    status: 'completed',
+    conclusion: 'failure',
+    run_id: overrides.run_id ?? 1001,
+    workflow: 'CI',
+    started_at: '2026-01-01T00:00:00Z',
+    duration: '1m30s',
+    ...overrides,
+  };
+}
+
+/** Create a successful GitHub Action check */
+function createPassedAction(
+  overrides: Partial<GitHubActionCheck> = {}
+): GitHubActionCheck {
+  return {
+    name: overrides.name ?? 'Lint',
+    status: 'completed',
+    conclusion: 'success',
+    run_id: overrides.run_id ?? 1002,
+    workflow: 'CI',
+    started_at: '2026-01-01T00:00:00Z',
+    duration: '0m45s',
+    ...overrides,
+  };
+}
+
+/** Create a failed external check */
+function createFailedExternal(
+  overrides: Partial<ExternalCheck> = {}
+): ExternalCheck {
+  return {
+    name: overrides.name ?? 'codecov/patch',
+    status: overrides.status ?? 'completed',
+    conclusion: 'failure',
+    url: 'https://codecov.io/test',
+    ...overrides,
+  };
+}
+
+/** Compute PR status from counts */
+function computeStatus(failed: number, pending: number): 'passed' | 'failed' | 'pending' {
+  if (failed > 0) return 'failed';
+  if (pending > 0) return 'pending';
+  return 'passed';
+}
+
+/** Build a result where one of two failed actions has extraction (partial extraction scenario) */
+function buildPartialExtractionResult(): WatchPRResult {
+  return buildResult([
+    createFailedAction({
+      name: 'Job A',
+      run_id: 1001,
+      extraction: { errors: [], summary: 'fail', totalErrors: 1 },
+    }),
+    createFailedAction({ name: 'Job B', run_id: 1002 }),
+  ]);
+}
+
+/** Build a result with only non-failure conclusions (cancelled, timed_out) */
+function buildNonFailureConclusionsResult(): WatchPRResult {
+  return buildResult([
+    { ...createPassedAction(), conclusion: 'cancelled' },
+    { ...createPassedAction({ name: 'Timeout', run_id: 2001 }), conclusion: 'timed_out' },
+  ]);
+}
+
+/** Build a WatchPRResult from check arrays */
+function buildResult(
+  actions: GitHubActionCheck[],
+  externals: ExternalCheck[] = []
+): WatchPRResult {
+  const failed = [...actions, ...externals].filter(c => c.conclusion === 'failure').length;
+  const passed = [...actions, ...externals].filter(c => c.conclusion === 'success').length;
+  const pending = [...actions, ...externals].filter(c => c.status !== 'completed').length;
+  return {
+    pr: basePR,
+    status: computeStatus(failed, pending),
+    checks: {
+      total: actions.length + externals.length,
+      passed,
+      failed,
+      pending,
+      github_actions: actions,
+      external_checks: externals,
+    },
+  };
+}
+
+// ============================================================================
+// allFailedChecksHaveExtraction (used in normal mode)
+// ============================================================================
+
+describe('allFailedChecksHaveExtraction', () => {
+  it('returns true when no checks are failed', () => {
+    const result = buildResult([createPassedAction()]);
+    expect(allFailedChecksHaveExtraction(result)).toBe(true);
+  });
+
+  it('returns false when a failed action has no extraction or log_file', () => {
+    const result = buildResult([
+      createFailedAction({ name: 'Job A' }),
+    ]);
+    expect(allFailedChecksHaveExtraction(result)).toBe(false);
+  });
+
+  it('returns true when all failed actions have extraction', () => {
+    const result = buildResult([
+      createFailedAction({
+        name: 'Job A',
+        extraction: { errors: [], summary: 'fail', totalErrors: 1 },
+      }),
+    ]);
+    expect(allFailedChecksHaveExtraction(result)).toBe(true);
+  });
+
+  it('returns true when all failed actions have log_file', () => {
+    const result = buildResult([
+      createFailedAction({ name: 'Job A', log_file: './test-logs/log.txt' }),
+    ]);
+    expect(allFailedChecksHaveExtraction(result)).toBe(true);
+  });
+
+  it('returns false when only some failed actions have extraction', () => {
+    const result = buildPartialExtractionResult();
+    expect(allFailedChecksHaveExtraction(result)).toBe(false);
+  });
+
+  it('returns true when all failed actions and externals are complete', () => {
+    const result = buildResult(
+      [createFailedAction({
+        extraction: { errors: [], summary: 'fail', totalErrors: 1 },
+      })],
+      [createFailedExternal({ status: 'completed' })],
+    );
+    expect(allFailedChecksHaveExtraction(result)).toBe(true);
+  });
+
+  it('returns false when a failed external check is not completed', () => {
+    const result = buildResult(
+      [createFailedAction({
+        extraction: { errors: [], summary: 'fail', totalErrors: 1 },
+      })],
+      [createFailedExternal({ status: 'in_progress' })],
+    );
+    expect(allFailedChecksHaveExtraction(result)).toBe(false);
+  });
+
+  it('returns true when checks array is completely empty (vacuous truth)', () => {
+    const result = buildResult([], []);
+    expect(allFailedChecksHaveExtraction(result)).toBe(true);
+  });
+
+  it('ignores non-failure conclusions like cancelled or timed_out', () => {
+    const result = buildNonFailureConclusionsResult();
+    // These are not 'failure', so they should not block extraction readiness
+    expect(allFailedChecksHaveExtraction(result)).toBe(true);
+  });
+});
+
+// ============================================================================
+// anyFailedCheckHasExtraction (used in fail-fast mode)
+// ============================================================================
+
+describe('anyFailedCheckHasExtraction', () => {
+  it('returns false when no checks are failed', () => {
+    const result = buildResult([createPassedAction()]);
+    expect(anyFailedCheckHasExtraction(result)).toBe(false);
+  });
+
+  it('returns false when failed actions have no extraction or log_file', () => {
+    const result = buildResult([
+      createFailedAction({ name: 'Job A', run_id: 1001 }),
+      createFailedAction({ name: 'Job B', run_id: 1002 }),
+    ]);
+    expect(anyFailedCheckHasExtraction(result)).toBe(false);
+  });
+
+  it('returns true when at least one failed action has extraction', () => {
+    const result = buildPartialExtractionResult();
+    expect(anyFailedCheckHasExtraction(result)).toBe(true);
+  });
+
+  it('returns true when at least one failed action has log_file', () => {
+    const result = buildResult([
+      createFailedAction({ name: 'Job A', run_id: 1001, log_file: './test-logs/log.txt' }),
+      createFailedAction({ name: 'Job B', run_id: 1002 }),
+    ]);
+    expect(anyFailedCheckHasExtraction(result)).toBe(true);
+  });
+
+  it('returns true when a failed external check is completed', () => {
+    const result = buildResult(
+      [],
+      [
+        createFailedExternal({ name: 'codecov', status: 'completed' }),
+        createFailedExternal({ name: 'sonar', status: 'in_progress' }),
+      ],
+    );
+    expect(anyFailedCheckHasExtraction(result)).toBe(true);
+  });
+
+  it('returns false when all failed externals are still in_progress', () => {
+    const result = buildResult(
+      [],
+      [
+        createFailedExternal({ name: 'codecov', status: 'in_progress' }),
+        createFailedExternal({ name: 'sonar', status: 'in_progress' }),
+      ],
+    );
+    expect(anyFailedCheckHasExtraction(result)).toBe(false);
+  });
+
+  it('returns false when checks array is completely empty', () => {
+    const result = buildResult([], []);
+    expect(anyFailedCheckHasExtraction(result)).toBe(false);
+  });
+
+  it('returns true with mixed: action extraction ready + external still in_progress', () => {
+    const result = buildResult(
+      [createFailedAction({
+        extraction: { errors: [], summary: 'fail', totalErrors: 1 },
+      })],
+      [createFailedExternal({ status: 'in_progress' })],
+    );
+    // Action extraction is enough — don't need to wait for external
+    expect(anyFailedCheckHasExtraction(result)).toBe(true);
+  });
+
+  it('ignores non-failure conclusions like cancelled or timed_out', () => {
+    const result = buildNonFailureConclusionsResult();
+    expect(anyFailedCheckHasExtraction(result)).toBe(false);
+  });
+
+  describe('fail-fast vs normal mode behavior difference', () => {
+    it('anyFailedCheck returns true but allFailedChecks returns false (the bug scenario)', () => {
+      // This is the exact scenario that caused the bug:
+      // 3 OS jobs fail, only 1 has extraction ready so far
+      const result = buildResult([
+        createFailedAction({
+          name: 'ubuntu',
+          run_id: 1001,
+          extraction: { errors: [], summary: 'link integrity failed', totalErrors: 2 },
+        }),
+        createFailedAction({ name: 'macos', run_id: 1002 }),
+        createFailedAction({ name: 'windows', run_id: 1003 }),
+      ]);
+
+      // fail-fast should exit — we have at least one extraction
+      expect(anyFailedCheckHasExtraction(result)).toBe(true);
+
+      // normal mode should wait — not all extractions are ready
+      expect(allFailedChecksHaveExtraction(result)).toBe(false);
+    });
+  });
+});

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.3 # Tracks vibe-validate package version
+version: 0.19.4-rc.1 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.4-rc.1 # Tracks vibe-validate package version
+version: 0.19.4-rc.2 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.4-rc.1",
+  "version": "0.19.4-rc.2",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.3",
+  "version": "0.19.4-rc.1",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- **Bug**: `--fail-fast` waited for ALL failed checks to have extraction before exiting, defeating its purpose
- **Fix**: Now exits as soon as ANY failed check has extraction ready (e.g., ubuntu fails and has logs → exit immediately, don't wait for macos/windows)
- Extracted exit-condition logic into testable `watch-pr-exit-conditions.ts` module with 19 unit tests, replacing 3 placeholder `expect(true).toBe(true)` tests

## Test plan
- [x] 19 unit tests covering all edge cases (empty checks, partial extraction, mixed action+external, non-failure conclusions)
- [x] Key regression test: "3 OS jobs fail, only 1 has extraction" → `anyFailedCheckHasExtraction` returns true, `allFailedChecksHaveExtraction` returns false
- [x] `pnpm validate` passes (all phases green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)