### PR TITLE
chore: bump vibe-agent-toolkit to ^0.1.32

### DIFF
--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@vibe-validate/cli": "workspace:*",
     "@vibe-validate/utils": "workspace:*",
-    "vibe-agent-toolkit": "^0.1.32-rc.1"
+    "vibe-agent-toolkit": "^0.1.32"
   },
   "devDependencies": {
     "@types/node": "^20.19.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,8 +332,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       vibe-agent-toolkit:
-        specifier: ^0.1.32-rc.1
-        version: 0.1.32-rc.1
+        specifier: ^0.1.32
+        version: 0.1.32
     devDependencies:
       '@types/node':
         specifier: ^20.19.26
@@ -1244,44 +1244,44 @@ packages:
     resolution: {integrity: sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vibe-agent-toolkit/agent-config@0.1.32-rc.1':
-    resolution: {integrity: sha512-t3AkWG7BzC+eAugwlAr4XSKq42Sc/jNrYGgTfRbyjA/yZHI7AA0MG00NdUgg8TH4IL09RHJ2v3mS8wa+fQHKUQ==}
+  '@vibe-agent-toolkit/agent-config@0.1.32':
+    resolution: {integrity: sha512-j/eeosiW+Tf48HNIEc+FDPHe7DJk3jJHDCOVijJ6uC0myrZlcNp14GNWhslU99MIZO2y+Xzlcs1dNwT+GJpJbA==}
 
-  '@vibe-agent-toolkit/agent-schema@0.1.32-rc.1':
-    resolution: {integrity: sha512-UnsupvvZKJZPRpJgrmVO7bNzW85GhjLyef6n1oHgf3trR1Ph7dGqngoAAu5xTHlirVEhwwNoFinwwkytHfo0MQ==}
+  '@vibe-agent-toolkit/agent-schema@0.1.32':
+    resolution: {integrity: sha512-fjzFp0Tw+sq02pMBOXZiJtiBBxWtTYDN2srKDyHPxBVlpMAw2vGcmpzXFIwgJMwE915ZhYXENML0lnbp7YXLDQ==}
 
-  '@vibe-agent-toolkit/agent-skills@0.1.32-rc.1':
-    resolution: {integrity: sha512-Rc41MNajOBVf9s00bH1gk+R9GIjkDSAhUkuSxcKB4Y3i8LBCLmOEnLKaAm5QMx5G5LnNdPWFWBIsmirDX/POqA==}
+  '@vibe-agent-toolkit/agent-skills@0.1.32':
+    resolution: {integrity: sha512-ffKM2ytn/MTBytwZBd5wwHSBZ8CE6bUQ1JHXnCqlYbxHEAeLRAlrzEfsu0/4josf0ssTEk0iTILY9IhleF3tGg==}
 
-  '@vibe-agent-toolkit/claude-marketplace@0.1.32-rc.1':
-    resolution: {integrity: sha512-x6Md10uDuClQmRfK4CversUQw2jd3bvzSGkbLIyTBx7aF8hY8Nwik8bEhrbnrg3EVZMwYPSK7X/9Kcin3Cf8UQ==}
+  '@vibe-agent-toolkit/claude-marketplace@0.1.32':
+    resolution: {integrity: sha512-1RQtp0NME4U6tNFFx7CYU1fMqr51HLIHn9RB6RgsV8T80rxoRFuYq1nWIGlZGX57l2GoSbNlf5GX4e4DzH/tAg==}
 
-  '@vibe-agent-toolkit/cli@0.1.32-rc.1':
-    resolution: {integrity: sha512-03fFVN3OHV8I3V6lvVcLJ2Pxb377hADv3K3qUq+4bmsxO065UMzkbrasQwRlxDmOMaZx3ZINbWe3Uvd3hfHlqQ==}
+  '@vibe-agent-toolkit/cli@0.1.32':
+    resolution: {integrity: sha512-pojYsDKFDd2RisTHVtoA/q6LU8FPE3BeMIcRsXzAmjuDA8CE3PLpJCKjXxZ3fEbO3X4XqIs6wT4hwaKQtugW+g==}
     hasBin: true
 
-  '@vibe-agent-toolkit/discovery@0.1.32-rc.1':
-    resolution: {integrity: sha512-LkmnCrZgff1B0eRWgBjmbI9FR8zWcRR3wjVh8AL7uxrtdJDgfaxzqtKB+cEg4NbHDCye5VSD8zAQLHPA2hMXQQ==}
+  '@vibe-agent-toolkit/discovery@0.1.32':
+    resolution: {integrity: sha512-SDu/VwkvaN849M9G56kzlU/Ig8lYUU/AWVhlgIqFWbMoym+PRxyyaHGJ8e2nkII7JsHcz/nOI9ffneCnIT3efg==}
 
-  '@vibe-agent-toolkit/gateway-mcp@0.1.32-rc.1':
-    resolution: {integrity: sha512-//no+sBPDyiB7ItGEz9phFAtYH5xWrE/Xoe/38UkS1JAdeXeQXqDdTnIBPfqShQpuTsou6eR4B8H8od6Y7zu6w==}
+  '@vibe-agent-toolkit/gateway-mcp@0.1.32':
+    resolution: {integrity: sha512-uV79OT1w1daetNCVUF/t4t6O6p922r16LJjjHOrqPfzCFeL7aNLAhBzKAhrQExuK6soyhBtmK7ig8rJTzxrwNw==}
 
-  '@vibe-agent-toolkit/rag-lancedb@0.1.32-rc.1':
-    resolution: {integrity: sha512-djjLqtpjtyRu6VtuzSs7kuPLFw2IuZzNoq753bQ7n72Z8uUrF1BmWruOZAW2yqCkj9qKlHE6+UjsZj8RCwDyMw==}
+  '@vibe-agent-toolkit/rag-lancedb@0.1.32':
+    resolution: {integrity: sha512-VJMemWzpuV4wCIXX39UqmweFJGP3oQHWv/s0cV6/ePYoZVhRLcyfDEU7VIIWGMxa1Hom6hNDI4DxzqJQ+pHy4g==}
 
-  '@vibe-agent-toolkit/rag@0.1.32-rc.1':
-    resolution: {integrity: sha512-s7UwUlJ9l9k2VwXzwsJ7ggu+iLTAsDhaSOWgNiIBg4vMYZhjFl7IGf7N67Tkgy68vc3xleDr7blG3EE4RSgRPQ==}
+  '@vibe-agent-toolkit/rag@0.1.32':
+    resolution: {integrity: sha512-MkUTRFwWaeF6mwf8kewTp107Rq5nEzrzQOJmY5oPtj0+DPUw0KH5NyaUUbgFgPPq5pmruJXNYV7hplHDJUjauQ==}
 
-  '@vibe-agent-toolkit/resources@0.1.32-rc.1':
-    resolution: {integrity: sha512-uq1hhORDY57/s3VK5Alx445jIDMMuU5woK/wgTa9n+AVYYH8R+flXyjYm7tNnN8PXdLyyPProP4bEAjsMXkvyg==}
+  '@vibe-agent-toolkit/resources@0.1.32':
+    resolution: {integrity: sha512-wy2Twy3JOv/QjDUeeXabXNBX16IjdeKvqMhkcCHazTBNTxOKn2RySQAtOY/Waklxtg0zBthj+Zho0v8SZlzj7A==}
 
-  '@vibe-agent-toolkit/utils@0.1.32-rc.1':
-    resolution: {integrity: sha512-oerjq59tBYyk29k9gXQteSyT8h8aJVXR2irICmMTnX+3PO1sZgTgO0R9AdUx8oJl8JkWk2VJLK4O9hftJMBtPw==}
+  '@vibe-agent-toolkit/utils@0.1.32':
+    resolution: {integrity: sha512-VdKlXii+0orJ095yF89FekcO1WnzSIFCGiQEswSNmUS0+UD35OAKMicVSyDybzZUDGD0CRzqZVC6CSlNjvaZzg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@vibe-agent-toolkit/vat-development-agents@0.1.32-rc.1':
-    resolution: {integrity: sha512-idjfJ9g1mmqWTLhvzA5t21NfQ0YdoEJqKeQ4+oyYAPSz3TxqhzJ1VuAcoZ/Zs4UOhdNwF5gNCysF9CUbbVPhBg==}
+  '@vibe-agent-toolkit/vat-development-agents@0.1.32':
+    resolution: {integrity: sha512-82wapjMBoqW9Z8Ye0mRKMx/Fnr1t4024vavcBqYs0utvNJ+zKl7eo5yINYO/6NEIGRqlj0V4cxGJfYJ94T00XQ==}
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -4008,8 +4008,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vibe-agent-toolkit@0.1.32-rc.1:
-    resolution: {integrity: sha512-CPmk3LegOZRiD3SrVCDJl9ETzA2niiKQ4vQUXP2SqGW+glxnSLOzDvWIb3IiLwKSLGAVBe6UdD8uEp3x/AtYdQ==}
+  vibe-agent-toolkit@0.1.32:
+    resolution: {integrity: sha512-+gEJ18YZS70MHd9Jr1+l4HruCQfPQGxMAApip2UgcSbCgIHPvE4z6hWRgWSaH9420VYTEbjoTiuK7K4oQ+7GFA==}
     hasBin: true
 
   vite-node@2.1.9:
@@ -5036,25 +5036,25 @@ snapshots:
       '@typescript-eslint/types': 8.50.1
       eslint-visitor-keys: 4.2.1
 
-  '@vibe-agent-toolkit/agent-config@0.1.32-rc.1(zod@3.25.76)':
+  '@vibe-agent-toolkit/agent-config@0.1.32(zod@3.25.76)':
     dependencies:
-      '@vibe-agent-toolkit/agent-schema': 0.1.32-rc.1
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.32
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       yaml: 2.8.2
     transitivePeerDependencies:
       - zod
 
-  '@vibe-agent-toolkit/agent-schema@0.1.32-rc.1':
+  '@vibe-agent-toolkit/agent-schema@0.1.32':
     dependencies:
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
 
-  '@vibe-agent-toolkit/agent-skills@0.1.32-rc.1':
+  '@vibe-agent-toolkit/agent-skills@0.1.32':
     dependencies:
-      '@vibe-agent-toolkit/agent-config': 0.1.32-rc.1(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-schema': 0.1.32-rc.1
-      '@vibe-agent-toolkit/resources': 0.1.32-rc.1
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-config': 0.1.32(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.32
+      '@vibe-agent-toolkit/resources': 0.1.32
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       adm-zip: 0.5.16
       picomatch: 4.0.3
       yaml: 2.8.2
@@ -5063,28 +5063,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vibe-agent-toolkit/claude-marketplace@0.1.32-rc.1':
+  '@vibe-agent-toolkit/claude-marketplace@0.1.32':
     dependencies:
-      '@vibe-agent-toolkit/agent-skills': 0.1.32-rc.1
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-skills': 0.1.32
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       ignore: 6.0.2
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@vibe-agent-toolkit/cli@0.1.32-rc.1':
+  '@vibe-agent-toolkit/cli@0.1.32':
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-config': 0.1.32-rc.1(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-schema': 0.1.32-rc.1
-      '@vibe-agent-toolkit/agent-skills': 0.1.32-rc.1
-      '@vibe-agent-toolkit/claude-marketplace': 0.1.32-rc.1
-      '@vibe-agent-toolkit/discovery': 0.1.32-rc.1(zod@3.25.76)
-      '@vibe-agent-toolkit/gateway-mcp': 0.1.32-rc.1
-      '@vibe-agent-toolkit/rag': 0.1.32-rc.1
-      '@vibe-agent-toolkit/rag-lancedb': 0.1.32-rc.1
-      '@vibe-agent-toolkit/resources': 0.1.32-rc.1
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-config': 0.1.32(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.32
+      '@vibe-agent-toolkit/agent-skills': 0.1.32
+      '@vibe-agent-toolkit/claude-marketplace': 0.1.32
+      '@vibe-agent-toolkit/discovery': 0.1.32(zod@3.25.76)
+      '@vibe-agent-toolkit/gateway-mcp': 0.1.32
+      '@vibe-agent-toolkit/rag': 0.1.32
+      '@vibe-agent-toolkit/rag-lancedb': 0.1.32
+      '@vibe-agent-toolkit/resources': 0.1.32
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       adm-zip: 0.5.16
       commander: 12.1.0
       js-yaml: 4.1.1
@@ -5100,28 +5100,28 @@ snapshots:
       - supports-color
       - ws
 
-  '@vibe-agent-toolkit/discovery@0.1.32-rc.1(zod@3.25.76)':
+  '@vibe-agent-toolkit/discovery@0.1.32(zod@3.25.76)':
     dependencies:
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       picomatch: 4.0.3
     transitivePeerDependencies:
       - zod
 
-  '@vibe-agent-toolkit/gateway-mcp@0.1.32-rc.1':
+  '@vibe-agent-toolkit/gateway-mcp@0.1.32':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      '@vibe-agent-toolkit/agent-schema': 0.1.32-rc.1
+      '@vibe-agent-toolkit/agent-schema': 0.1.32
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@vibe-agent-toolkit/rag-lancedb@0.1.32-rc.1':
+  '@vibe-agent-toolkit/rag-lancedb@0.1.32':
     dependencies:
       '@lancedb/lancedb': 0.23.0(apache-arrow@18.1.0)
-      '@vibe-agent-toolkit/rag': 0.1.32-rc.1
-      '@vibe-agent-toolkit/resources': 0.1.32-rc.1
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/rag': 0.1.32
+      '@vibe-agent-toolkit/resources': 0.1.32
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       apache-arrow: 18.1.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -5131,10 +5131,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@vibe-agent-toolkit/rag@0.1.32-rc.1':
+  '@vibe-agent-toolkit/rag@0.1.32':
     dependencies:
-      '@vibe-agent-toolkit/resources': 0.1.32-rc.1
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/resources': 0.1.32
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       gpt-tokenizer: 2.9.0
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
@@ -5149,10 +5149,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@vibe-agent-toolkit/resources@0.1.32-rc.1':
+  '@vibe-agent-toolkit/resources@0.1.32':
     dependencies:
-      '@vibe-agent-toolkit/agent-schema': 0.1.32-rc.1
-      '@vibe-agent-toolkit/utils': 0.1.32-rc.1(zod@3.25.76)
+      '@vibe-agent-toolkit/agent-schema': 0.1.32
+      '@vibe-agent-toolkit/utils': 0.1.32(zod@3.25.76)
       ajv: 8.17.1
       github-slugger: 2.0.0
       js-yaml: 4.1.1
@@ -5167,7 +5167,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vibe-agent-toolkit/utils@0.1.32-rc.1(zod@3.25.76)':
+  '@vibe-agent-toolkit/utils@0.1.32(zod@3.25.76)':
     dependencies:
       handlebars: 4.7.9
       ignore: 7.0.5
@@ -5175,10 +5175,10 @@ snapshots:
       which: 5.0.0
       zod: 3.25.76
 
-  '@vibe-agent-toolkit/vat-development-agents@0.1.32-rc.1':
+  '@vibe-agent-toolkit/vat-development-agents@0.1.32':
     dependencies:
-      '@vibe-agent-toolkit/agent-schema': 0.1.32-rc.1
-      '@vibe-agent-toolkit/cli': 0.1.32-rc.1
+      '@vibe-agent-toolkit/agent-schema': 0.1.32
+      '@vibe-agent-toolkit/cli': 0.1.32
       yaml: 2.8.2
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -8606,10 +8606,10 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vibe-agent-toolkit@0.1.32-rc.1:
+  vibe-agent-toolkit@0.1.32:
     dependencies:
-      '@vibe-agent-toolkit/cli': 0.1.32-rc.1
-      '@vibe-agent-toolkit/vat-development-agents': 0.1.32-rc.1
+      '@vibe-agent-toolkit/cli': 0.1.32
+      '@vibe-agent-toolkit/vat-development-agents': 0.1.32
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - bare-abort-controller


### PR DESCRIPTION
## Summary
- Bumps `vibe-agent-toolkit` from `^0.1.32-rc.1` to `^0.1.32` (stable)
- Lockfile updated so all `@vibe-agent-toolkit/*` subpackages resolve to `0.1.32`

## Test plan
- [x] `pnpm install` resolves `vat@0.1.32`
- [x] `pnpm exec vv validate --force` — all 8 steps pass (Pre-Qualification + Testing)
- [x] `vat audit` — exit 0 (pre-existing warnings only, 0 errors)
- [x] `pnpm test` — 1214 passed, 5 skipped across 14 tasks
- [x] `vat build` via prepare script — success

🤖 Generated with [Claude Code](https://claude.ai/code)