### PR TITLE
chore: bump GitHub Actions to v6 + v0.19.4-rc.3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     name: Upload Coverage to Codecov
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup pnpm
@@ -21,7 +21,7 @@ jobs:
         with:
           version: "9"
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for CHANGELOG extraction
 
@@ -25,7 +25,7 @@ jobs:
           version: "9"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: pnpm

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run vibe-validate validation
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup pnpm
@@ -24,7 +24,7 @@ jobs:
         with:
           version: "9"
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -55,7 +55,7 @@ jobs:
       - name: Check all validation jobs
         run: |-
           if [ "${{ needs.validate.result }}" != "success" ]; then
-                      echo "❌ Some validation checks failed"
-                      exit 1
-                    fi
-                    echo "✅ All validation checks passed!"
+            echo "❌ Some validation checks failed"
+            exit 1
+          fi
+          echo "✅ All validation checks passed!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`generate-workflow`** — Generated workflows now use `actions/checkout@v6` and `actions/setup-node@v6` (upgraded from `v4`). Existing users should re-run `vv generate-workflow` to pick up the new versions.
+
 ### Fixed
 
 - **`watch-pr --fail-fast`** — Now exits on first failure extraction instead of waiting for all failures, matching the documented "exit immediately" behavior

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/generate-workflow.ts
+++ b/packages/cli/src/commands/generate-workflow.ts
@@ -36,8 +36,8 @@ import {
 } from '../utils/package-manager-commands.js';
 
 // GitHub Actions constants
-const ACTIONS_CHECKOUT_V4 = 'actions/checkout@v4';
-const ACTIONS_SETUP_NODE_V4 = 'actions/setup-node@v4';
+const ACTIONS_CHECKOUT_V6 = 'actions/checkout@v6';
+const ACTIONS_SETUP_NODE_V6 = 'actions/setup-node@v6';
 const ACTIONS_SETUP_BUN_V2 = 'oven-sh/setup-bun@v2';
 const ACTIONS_SETUP_PNPM_V2 = 'pnpm/action-setup@v2';
 const WORKFLOW_PROPERTY_NODE_VERSION = 'node-version';
@@ -210,7 +210,7 @@ function buildCommonJobSteps(params: {
 }): GitHubWorkflowStep[] {
   const steps: GitHubWorkflowStep[] = [
     {
-      uses: ACTIONS_CHECKOUT_V4,
+      uses: ACTIONS_CHECKOUT_V6,
       with: {
         [WORKFLOW_PROPERTY_FETCH_DEPTH]: 0  // Fetch all history for git-based checks (doctor command)
       }
@@ -240,7 +240,7 @@ function buildCommonJobSteps(params: {
   if (!params.skipNodeSetup) {
     steps.push({
       name: `Setup Node.js ${params.nodeVersionLabel}`,
-      uses: ACTIONS_SETUP_NODE_V4,
+      uses: ACTIONS_SETUP_NODE_V6,
       with: {
         [WORKFLOW_PROPERTY_NODE_VERSION]: params.nodeVersionLabel,
         ...params.nodeCacheConfig,

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.4-rc.2'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.4-rc.3'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/commands/generate-workflow.test.ts
+++ b/packages/cli/test/commands/generate-workflow.test.ts
@@ -281,8 +281,8 @@ describe('generate-workflow command', () => {
       const workflow = generateAndParseWorkflow(mockConfig);
 
       const job = workflow.jobs['validate'];
-      expect(job.steps[0].uses).toBe('actions/checkout@v4');
-      expect(job.steps.some((s: any) => s.uses === 'actions/setup-node@v4')).toBe(true);
+      expect(job.steps[0].uses).toBe('actions/checkout@v6');
+      expect(job.steps.some((s: any) => s.uses === 'actions/setup-node@v6')).toBe(true);
     });
 
     it('should add all-validation-passed gate job', () => {
@@ -660,7 +660,7 @@ describe('generate-workflow command', () => {
 
         // Should have BOTH Bun and Node.js setup
         const bunStep = expectStepWithUses(job, 'oven-sh/setup-bun@v2');
-        const nodeStep = expectStepWithUses(job, 'actions/setup-node@v4');
+        const nodeStep = expectStepWithUses(job, 'actions/setup-node@v6');
 
         // Verify Node.js setup uses matrix variable
         expect(nodeStep.with['node-version']).toBe('${{ matrix.node }}');
@@ -686,7 +686,7 @@ describe('generate-workflow command', () => {
 
         // Should detect Bun and include both setups
         expectStepWithUses(job, 'oven-sh/setup-bun@v2');
-        const nodeStep = expectStepWithUses(job, 'actions/setup-node@v4');
+        const nodeStep = expectStepWithUses(job, 'actions/setup-node@v6');
 
         // Node.js setup should use matrix variable and not have cache
         expect(nodeStep.with['node-version']).toBe('${{ matrix.node }}');
@@ -721,7 +721,7 @@ describe('generate-workflow command', () => {
 
         const workflow = generateAndParseWorkflow(config, { packageManager: 'pnpm' });
         const job = workflow.jobs['validate'];
-        const nodeStep = findStepByUses(job, 'actions/setup-node@v4');
+        const nodeStep = findStepByUses(job, 'actions/setup-node@v6');
 
         expect(nodeStep.with['registry-url']).toBe('https://npm.pkg.github.com');
       });
@@ -737,7 +737,7 @@ describe('generate-workflow command', () => {
           enableCoverage: true,
         });
         const coverageJob = workflow.jobs['validate-coverage'];
-        const nodeStep = findStepByUses(coverageJob, 'actions/setup-node@v4');
+        const nodeStep = findStepByUses(coverageJob, 'actions/setup-node@v6');
 
         expect(nodeStep.with['registry-url']).toBe('https://npm.pkg.github.com');
       });
@@ -745,7 +745,7 @@ describe('generate-workflow command', () => {
       it('should NOT add registry-url when ci.registryUrl is not set', () => {
         const workflow = generateAndParseWorkflow(baseMockConfig, { packageManager: 'pnpm' });
         const job = workflow.jobs['validate'];
-        const nodeStep = findStepByUses(job, 'actions/setup-node@v4');
+        const nodeStep = findStepByUses(job, 'actions/setup-node@v6');
 
         expect(nodeStep.with['registry-url']).toBeUndefined();
       });
@@ -932,10 +932,10 @@ describe('generate-workflow command', () => {
         const job = workflow.jobs['validate'];
 
         // Find step indices
-        const checkoutIdx = findStepIndexByUses(job, 'actions/checkout@v4');
+        const checkoutIdx = findStepIndexByUses(job, 'actions/checkout@v6');
         const javaIdx = findStepIndexByName(job, 'Setup Java');
         const pnpmIdx = findStepIndexByName(job, 'Setup pnpm');
-        const nodeIdx = findStepIndexByUses(job, 'actions/setup-node@v4');
+        const nodeIdx = findStepIndexByUses(job, 'actions/setup-node@v6');
 
         expect(javaIdx).toBeGreaterThan(checkoutIdx);
         expect(javaIdx).toBeLessThan(pnpmIdx);
@@ -958,7 +958,7 @@ describe('generate-workflow command', () => {
         });
 
         const coverageJob = workflow.jobs['validate-coverage'];
-        const checkoutIdx = findStepIndexByUses(coverageJob, 'actions/checkout@v4');
+        const checkoutIdx = findStepIndexByUses(coverageJob, 'actions/checkout@v6');
         const customIdx = findStepIndexByName(coverageJob, 'Custom setup');
         const pnpmIdx = findStepIndexByName(coverageJob, 'Setup pnpm');
 
@@ -971,7 +971,7 @@ describe('generate-workflow command', () => {
         const job = workflow.jobs['validate'];
 
         // Should go directly from checkout to pnpm setup
-        expect(job.steps[0].uses).toBe('actions/checkout@v4');
+        expect(job.steps[0].uses).toBe('actions/checkout@v6');
         expect(job.steps[1].name).toBe('Setup pnpm');
       });
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/SKILL.md
+++ b/packages/vibe-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibe-validate
-version: 0.19.4-rc.2 # Tracks vibe-validate package version
+version: 0.19.4-rc.3 # Tracks vibe-validate package version
 description: Expert guidance for vibe-validate, an LLM-optimized validation orchestration tool. Use when working with vibe-validate commands, configuration, pre-commit workflows, or validation orchestration in TypeScript projects.
 model: claude-sonnet-4-5
 tools:

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.4-rc.2",
+  "version": "0.19.4-rc.3",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout@v4` → `v6` and `actions/setup-node@v4` → `v6` in `generate-workflow` templates
- Regenerates the repo's own `.github/workflows/{validate,coverage,publish}.yml` to use v6
- Bumps version to `0.19.4-rc.3` (RC — changes stay under `[Unreleased]` in CHANGELOG)

## Test plan
- [x] `pnpm exec vv validate --force` — all 8 steps pass (Pre-Qualification + Testing)
- [x] Generated workflow tests updated to match new action versions
- [x] Local generated workflows (`.github/workflows/*.yml`) regenerated consistently
- [ ] CI on this PR runs successfully with the v6 actions

🤖 Generated with [Claude Code](https://claude.ai/code)