### PR TITLE
feat: pass-through nested vv run via VV_PARENT_CONTEXT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Nested `vv run` pass-through** — When a `package.json` script wraps a tool with `vibe-validate run` and is invoked from `vibe-validate validate`, the inner `vv run` now switches automatically to pass-through mode: it inherits the parent's stdio, propagates the exit code, and skips its own capture/extract/cache. The outer captures the real underlying tool's output (vitest, eslint, etc.) instead of an inner YAML summary, so error extraction runs on actual data and `vv watch-pr` can recover failures from CI logs. A depth cap of 3 fails loudly on recursive misconfiguration. Signaled via the new `VV_PARENT_CONTEXT` environment variable, set automatically by the parent.
+- **`vv doctor` nested-invocation reporting** — Doctor now reports `Running inside parent vibe-validate (runId=…, depth=N, step="…")` when invoked under a parent vv process, and fails loudly when `VV_PARENT_CONTEXT` is set but malformed.
+
 ### Changed
 
 - **`generate-workflow`** — Generated workflows now use `pnpm/action-setup@v5` (upgraded from `v2`). Existing users should re-run `vv generate-workflow` to pick up the new version and silence Node.js 20 deprecation warnings in CI.

--- a/docs/skills/vv-watch-pr/SKILL.md
+++ b/docs/skills/vv-watch-pr/SKILL.md
@@ -152,6 +152,8 @@ Run it whenever the branch list gets long, or as part of a post-merge ritual.
 
 **"Extracted errors are empty despite a failure"** — the extractor didn't recognize the tool's output format. See `vibe-validate:authoring-extractors` for how to build a custom extractor and validate it against the CI output.
 
+**"Inner `vv run` swallowed the failure output"** — if your `package.json` test scripts wrap commands in `vibe-validate run "vitest ..."` and you run them from `vibe-validate validate`, the inner `vv run` automatically switches to **pass-through mode**: it inherits stdio, propagates the exit code, and skips its own capture/extract/cache so the outer captures the real underlying tool's output. Extraction then runs on actual data instead of an inner YAML summary, and `vv watch-pr` can recover the real failure from the CI log. This is signaled via the `VV_PARENT_CONTEXT` env var, set automatically by the parent. A depth cap of 3 fails loudly on recursive misconfiguration. `vv doctor` reports `Running inside parent vibe-validate (runId=…, depth=N, step="…")` when invoked under a parent.
+
 ## See also
 
 - `vibe-validate:vv-validate-dev-loop` — the local validation loop, state queries, and `vv run`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -67,7 +67,6 @@ const CHECK_PRE_COMMIT_SECRET_SCANNING = 'Pre-commit secret scanning';
 const CHECK_VIBE_VALIDATE_VERSION = 'vibe-validate version';
 const CHECK_DEPENDENCY_LOCK_CHECK = 'Dependency lock check configuration';
 const CHECK_NESTED_INVOCATION = 'Nested invocation';
-const CHECK_PARENT_CONTEXT_ENV = 'Parent context env var';
 
 // Common message constants
 const MSG_SKIPPED_NOT_IN_GIT = 'Skipped (not in git repository)';
@@ -1252,7 +1251,7 @@ function checkParentContext(): DoctorCheckResult {
     };
   } catch (error) {
     return {
-      name: CHECK_PARENT_CONTEXT_ENV,
+      name: CHECK_NESTED_INVOCATION,
       passed: false,
       message: `Invalid ${PARENT_CONTEXT_ENV}: ${error instanceof Error ? error.message : String(error)}`,
       suggestion: `Unset the env var and retry: unset ${PARENT_CONTEXT_ENV}`,

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -15,6 +15,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { getMainBranch, getRemoteOrigin, type VibeValidateConfig } from '@vibe-validate/config';
+import { readParentContext, PARENT_CONTEXT_ENV } from '@vibe-validate/core';
 import {
   executeGitCommand,
   isGitRepository,
@@ -65,6 +66,8 @@ const CHECK_GITHUB_ACTIONS_WORKFLOW = 'GitHub Actions workflow';
 const CHECK_PRE_COMMIT_SECRET_SCANNING = 'Pre-commit secret scanning';
 const CHECK_VIBE_VALIDATE_VERSION = 'vibe-validate version';
 const CHECK_DEPENDENCY_LOCK_CHECK = 'Dependency lock check configuration';
+const CHECK_NESTED_INVOCATION = 'Nested invocation';
+const CHECK_PARENT_CONTEXT_ENV = 'Parent context env var';
 
 // Common message constants
 const MSG_SKIPPED_NOT_IN_GIT = 'Skipped (not in git repository)';
@@ -1226,6 +1229,38 @@ async function checkDependencyLockCheck(config?: VibeValidateConfig | null): Pro
 }
 
 /**
+ * Check if vibe-validate is running inside a parent vibe-validate invocation
+ *
+ * Reports the nested context when VV_PARENT_CONTEXT is set, and fails if the
+ * env var is present but malformed.
+ */
+function checkParentContext(): DoctorCheckResult {
+  try {
+    const parentCtx = readParentContext();
+    if (parentCtx) {
+      return {
+        name: CHECK_NESTED_INVOCATION,
+        passed: true,
+        message: `Running inside parent vibe-validate (runId=${parentCtx.runId}, depth=${String(parentCtx.depth)}, step="${parentCtx.stepName}")`,
+      };
+    }
+    // VV_PARENT_CONTEXT is unset — not nested, nothing to report
+    return {
+      name: CHECK_NESTED_INVOCATION,
+      passed: true,
+      message: 'Not running inside a parent vibe-validate invocation',
+    };
+  } catch (error) {
+    return {
+      name: CHECK_PARENT_CONTEXT_ENV,
+      passed: false,
+      message: `Invalid ${PARENT_CONTEXT_ENV}: ${error instanceof Error ? error.message : String(error)}`,
+      suggestion: `Unset the env var and retry: unset ${PARENT_CONTEXT_ENV}`,
+    };
+  }
+}
+
+/**
  * Run all doctor checks
  */
 export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResult> {
@@ -1276,6 +1311,7 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResu
     await checkPreCommitHook(config),
     await checkSecretScanning(config),
     await checkDependencyLockCheck(config),
+    checkParentContext(),
     checkGitignoreStateFile(),
     checkValidationState(),
     checkCacheMigration(),

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -8,8 +8,17 @@
 import { writeFile, readFile } from 'node:fs/promises';
 import { join, resolve, relative } from 'node:path';
 
-import type { OutputLine } from '@vibe-validate/core';
-import { spawnCommand, parseVibeValidateOutput, getGitRoot, getTempFilename } from '@vibe-validate/core';
+import type { OutputLine, ParentContext } from '@vibe-validate/core';
+import {
+  spawnCommand,
+  parseVibeValidateOutput,
+  getGitRoot,
+  getTempFilename,
+  readParentContext,
+  buildChildContext,
+  serializeForEnv,
+  PARENT_CONTEXT_ENV,
+} from '@vibe-validate/core';
 import { autoDetectAndExtract } from '@vibe-validate/extractors';
 import { getGitTreeHash, encodeRunCacheKey, extractYamlWithPreamble, addNote, readNote, type NotesRef } from '@vibe-validate/git';
 import type { RunCacheNote } from '@vibe-validate/history';
@@ -22,6 +31,8 @@ import { type RunResult } from '../schemas/run-result-schema.js';
 import { getCommandName } from '../utils/command-name.js';
 import { logDebug, logWarning } from '../utils/logger.js';
 import { getRunOutputDir, ensureDir } from '../utils/temp-files.js';
+
+const NOT_IN_GIT_REPO_ERROR = 'Not in a git repository';
 
 export function runCommand(program: Command): void {
   program
@@ -94,6 +105,27 @@ export function runCommand(program: Command): void {
         // No command or command starts with a flag - show run command help
         showRunHelp();
         process.exit(0);
+      }
+
+      // Pass-through mode: when running inside another vibe-validate command
+      // (parent set VV_PARENT_CONTEXT with capturing=true), we just exec the
+      // command with inherited stdio and propagate the exit code. The parent
+      // handles capture, extraction, caching, and YAML emission.
+      let parent: ParentContext | null;
+      try {
+        parent = readParentContext();
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(2);
+      }
+      if (parent?.capturing) {
+        try {
+          const exitCode = await executePassThrough(commandString, parent, actualOptions.cwd);
+          process.exit(exitCode);
+        } catch (error) {
+          console.error(error instanceof Error ? error.message : String(error));
+          process.exit(1);
+        }
       }
 
       try {
@@ -234,7 +266,7 @@ function getWorkingDirectory(explicitCwd?: string): string {
     const gitRoot = getGitRoot();
 
     if (!gitRoot) {
-      throw new Error('Not in a git repository');
+      throw new Error(NOT_IN_GIT_REPO_ERROR);
     }
 
     // Use explicit --cwd if provided
@@ -432,6 +464,58 @@ function stripAnsiCodes(text: string): string {
 }
 
 /**
+ * Pass-through execution: when running inside another vibe-validate command,
+ * spawn the underlying command with inherited stdio and propagate the exit code.
+ *
+ * No capture, no YAML emit, no cache, no output files — the parent handles all of that.
+ *
+ * Re-exports VV_PARENT_CONTEXT with depth+1 so grandchildren get a correct
+ * ancestry chain. If `buildChildContext` would exceed MAX_NESTED_DEPTH, it
+ * throws — which the action handler converts into a non-zero exit with a
+ * "depth exceeded" message on stderr.
+ */
+async function executePassThrough(
+  commandString: string,
+  parent: ParentContext,
+  explicitCwd?: string
+): Promise<number> {
+  const childCtx = buildChildContext(parent, {
+    runId: parent.runId,
+    treeHash: parent.treeHash,
+    stepName: parent.stepName,
+    ...(parent.phaseName ? { phaseName: parent.phaseName } : {}),
+    outputDir: parent.outputDir,
+    verbose: parent.verbose,
+    forceExecution: parent.forceExecution,
+  });
+
+  let resolvedCwd: string | undefined;
+  if (explicitCwd) {
+    const gitRoot = getGitRoot();
+    if (!gitRoot) {
+      throw new Error(NOT_IN_GIT_REPO_ERROR);
+    }
+    resolvedCwd = resolve(gitRoot, explicitCwd);
+    const normalizedResolvedCwd = normalizePath(resolvedCwd);
+    const normalizedGitRoot = normalizePath(gitRoot);
+    if (!normalizedResolvedCwd.startsWith(normalizedGitRoot)) {
+      throw new Error(`Invalid --cwd: "${explicitCwd}" - must be within git repository`);
+    }
+  }
+
+  const child = spawnCommand(commandString, {
+    cwd: resolvedCwd,
+    stdio: 'inherit',
+    env: { [PARENT_CONTEXT_ENV]: serializeForEnv(childCtx) },
+  });
+
+  return new Promise<number>((resolvePromise, rejectPromise) => {
+    child.on('close', code => resolvePromise(code ?? 1));
+    child.on('error', err => rejectPromise(err));
+  });
+}
+
+/**
  * Execute a command and extract errors from its output
  */
 async function executeAndExtract(commandString: string, explicitCwd?: string): Promise<{
@@ -447,7 +531,7 @@ async function executeAndExtract(commandString: string, explicitCwd?: string): P
       try {
         const gitRoot = getGitRoot();
         if (!gitRoot) {
-          rejectPromise(new Error('Not in a git repository'));
+          rejectPromise(new Error(NOT_IN_GIT_REPO_ERROR));
           return;
         }
         resolvedCwd = resolve(gitRoot, explicitCwd);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -119,13 +119,16 @@ export function runCommand(program: Command): void {
         process.exit(2);
       }
       if (parent?.capturing) {
+        let passThroughExitCode: number;
         try {
-          const exitCode = await executePassThrough(commandString, parent, actualOptions.cwd);
-          process.exit(exitCode);
+          passThroughExitCode = await executePassThrough(commandString, parent, actualOptions.cwd);
         } catch (error) {
           console.error(error instanceof Error ? error.message : String(error));
           process.exit(1);
         }
+        // process.exit must be outside the try/catch — otherwise a test mock
+        // that throws on exit would re-trigger the catch path
+        process.exit(passThroughExitCode);
       }
 
       try {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -464,6 +464,31 @@ function stripAnsiCodes(text: string): string {
 }
 
 /**
+ * Resolve an explicit --cwd argument to an absolute path, ensuring it stays
+ * within the git repository root.
+ *
+ * Both sides of the comparison are normalized AND converted to forward slashes
+ * to guarantee byte-identical comparison on Windows (where path separators may
+ * mix `\` and `/` after `path.resolve`).
+ *
+ * @throws if not in a git repo, or if `explicitCwd` resolves outside the git root
+ */
+function resolveCwdWithinGitRoot(explicitCwd: string): string {
+  const gitRoot = getGitRoot();
+  if (!gitRoot) {
+    throw new Error(NOT_IN_GIT_REPO_ERROR);
+  }
+  const resolvedCwd = resolve(gitRoot, explicitCwd);
+  // toForwardSlash + normalizePath ensures byte-identical comparison on Windows
+  const normalizedCwd = toForwardSlash(normalizePath(resolvedCwd));
+  const normalizedRoot = toForwardSlash(normalizePath(gitRoot));
+  if (!normalizedCwd.startsWith(normalizedRoot)) {
+    throw new Error(`Invalid --cwd: "${explicitCwd}" - must be within git repository`);
+  }
+  return resolvedCwd;
+}
+
+/**
  * Pass-through execution: when running inside another vibe-validate command,
  * spawn the underlying command with inherited stdio and propagate the exit code.
  *
@@ -489,19 +514,7 @@ async function executePassThrough(
     forceExecution: parent.forceExecution,
   });
 
-  let resolvedCwd: string | undefined;
-  if (explicitCwd) {
-    const gitRoot = getGitRoot();
-    if (!gitRoot) {
-      throw new Error(NOT_IN_GIT_REPO_ERROR);
-    }
-    resolvedCwd = resolve(gitRoot, explicitCwd);
-    const normalizedResolvedCwd = normalizePath(resolvedCwd);
-    const normalizedGitRoot = normalizePath(gitRoot);
-    if (!normalizedResolvedCwd.startsWith(normalizedGitRoot)) {
-      throw new Error(`Invalid --cwd: "${explicitCwd}" - must be within git repository`);
-    }
-  }
+  const resolvedCwd = explicitCwd ? resolveCwdWithinGitRoot(explicitCwd) : undefined;
 
   const child = spawnCommand(commandString, {
     cwd: resolvedCwd,
@@ -529,23 +542,9 @@ async function executeAndExtract(commandString: string, explicitCwd?: string): P
     let resolvedCwd: string | undefined;
     if (explicitCwd) {
       try {
-        const gitRoot = getGitRoot();
-        if (!gitRoot) {
-          rejectPromise(new Error(NOT_IN_GIT_REPO_ERROR));
-          return;
-        }
-        resolvedCwd = resolve(gitRoot, explicitCwd);
-
-        // Security: Validate path is within git root
-        // Normalize both paths for cross-platform comparison (Windows uses backslashes, git root may use forward slashes)
-        const normalizedResolvedCwd = normalizePath(resolvedCwd);
-        const normalizedGitRoot = normalizePath(gitRoot);
-        if (!normalizedResolvedCwd.startsWith(normalizedGitRoot)) {
-          rejectPromise(new Error(`Invalid --cwd: "${explicitCwd}" - must be within git repository`));
-          return;
-        }
+        resolvedCwd = resolveCwdWithinGitRoot(explicitCwd);
       } catch (error) {
-        rejectPromise(new Error(`Failed to resolve --cwd: ${error instanceof Error ? error.message : 'unknown error'}`));
+        rejectPromise(error instanceof Error ? error : new Error(String(error)));
         return;
       }
     }

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.4'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.5-rc.1'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/commands/doctor.test.ts
+++ b/packages/cli/test/commands/doctor.test.ts
@@ -2044,15 +2044,16 @@ describe('doctor command', () => {
       });
     });
 
-    it('should not report parent context check in filtered output when env var is unset', async () => {
+    it('should pass with informational message when VV_PARENT_CONTEXT is unset', async () => {
       delete process.env['VV_PARENT_CONTEXT'];
 
       await mockDoctorDefaults();
-      // In non-verbose mode, passing checks without suggestions are filtered out
-      const result = await runDoctor({ verbose: false });
+      const result = await runDoctor({ verbose: true });
 
-      const nestedCheck = result.checks.find(c => c.name === 'Nested invocation');
-      expect(nestedCheck).toBeUndefined();
+      assertCheck(result, 'Nested invocation', {
+        passed: true,
+        messageContains: 'Not running inside',
+      });
     });
 
     it('should fail and report error when VV_PARENT_CONTEXT contains invalid JSON', async () => {
@@ -2061,7 +2062,7 @@ describe('doctor command', () => {
       await mockDoctorDefaults();
       const result = await runDoctor({ verbose: true });
 
-      assertCheck(result, 'Parent context env var', {
+      assertCheck(result, 'Nested invocation', {
         passed: false,
         messageContains: 'VV_PARENT_CONTEXT',
       });

--- a/packages/cli/test/commands/doctor.test.ts
+++ b/packages/cli/test/commands/doctor.test.ts
@@ -15,6 +15,7 @@ import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
 import type { VibeValidateConfig } from '@vibe-validate/config';
+import { normalizedTmpdir } from '@vibe-validate/utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { runDoctor, type DoctorCheckResult } from '../../src/commands/doctor.js';
@@ -186,7 +187,7 @@ describe('doctor command', () => {
       const result = await runDoctor({ verbose: true });
 
       expect(result.allPassed).toBe(true);
-      expect(result.checks).toHaveLength(19);
+      expect(result.checks).toHaveLength(20);
       expect(result.checks.every(c => c.passed)).toBe(true);
     });
 
@@ -317,7 +318,7 @@ describe('doctor command', () => {
       const result = await runDoctor({ verbose: true });
 
       // Verify that all 16 checks ran (not just the config check)
-      expect(result.checks).toHaveLength(19);
+      expect(result.checks).toHaveLength(20);
 
       // Config check should fail
       assertCheck(result, 'Configuration valid', {
@@ -331,10 +332,10 @@ describe('doctor command', () => {
       assertCheck(result, 'Git installed', { passed: true });
       assertCheck(result, 'Git repository', { passed: true });
 
-      // Summary should show 18/19 passed (only config check fails)
+      // Summary should show 19/20 passed (only config check fails)
       expect(result.allPassed).toBe(false);
-      expect(result.totalChecks).toBe(19);
-      expect(result.passedChecks).toBe(18);
+      expect(result.totalChecks).toBe(20);
+      expect(result.passedChecks).toBe(19);
     });
 
     it('should detect not in git repository', async () => {
@@ -462,7 +463,7 @@ describe('doctor command', () => {
 
       const result = await runDoctor({ verbose: true });
 
-      expect(result.checks).toHaveLength(19);
+      expect(result.checks).toHaveLength(20);
       expect(result.verboseMode).toBe(true);
     });
 
@@ -522,7 +523,7 @@ describe('doctor command', () => {
 
       // Verbose mode should show ALL 16 checks (including passing ones)
       expect(result.verboseMode).toBe(true);
-      expect(result.checks).toHaveLength(19); // All checks
+      expect(result.checks).toHaveLength(20); // All checks
       expect(result.allPassed).toBe(false); // Has failures
 
       const failedChecks = result.checks.filter(c => !c.passed);
@@ -1247,7 +1248,7 @@ describe('doctor command', () => {
 
       const result = await runDoctor({ verbose: true, versionChecker: mockVersionChecker });
 
-      expect(result.checks).toHaveLength(19);
+      expect(result.checks).toHaveLength(20);
       assertCheck(result, 'vibe-validate version', { passed: true });
     });
 
@@ -1269,7 +1270,7 @@ describe('doctor command', () => {
 
       expect(duration).toBeLessThan(5000); // Should be fast (<5s without network)
       assertCheck(result, 'vibe-validate version', { passed: true });
-      expect(result.checks).toHaveLength(19);
+      expect(result.checks).toHaveLength(20);
     });
   });
 
@@ -1994,6 +1995,76 @@ describe('doctor command', () => {
       });
 
       mockCheckHealth.mockRestore();
+    });
+  });
+
+  describe('checkParentContext() - Nested invocation reporting', () => {
+    let savedParentCtx: string | undefined;
+
+    beforeEach(() => {
+      savedParentCtx = process.env['VV_PARENT_CONTEXT'];
+    });
+
+    afterEach(() => {
+      if (savedParentCtx === undefined) {
+        delete process.env['VV_PARENT_CONTEXT'];
+      } else {
+        process.env['VV_PARENT_CONTEXT'] = savedParentCtx;
+      }
+    });
+
+    it('should report nested invocation when VV_PARENT_CONTEXT is set', async () => {
+      process.env['VV_PARENT_CONTEXT'] = JSON.stringify({
+        runId: 'run-abc123',
+        treeHash: 'hash-xyz',
+        depth: 2,
+        stepName: 'integration',
+        outputDir: normalizedTmpdir() + '/vv-out',
+        capturing: true,
+        caching: true,
+        extracting: true,
+        verbose: false,
+        forceExecution: false,
+      });
+
+      await mockDoctorDefaults();
+      const result = await runDoctor({ verbose: true });
+
+      assertCheck(result, 'Nested invocation', {
+        passed: true,
+        messageContains: 'run-abc123',
+      });
+      assertCheck(result, 'Nested invocation', {
+        passed: true,
+        messageContains: 'depth=2',
+      });
+      assertCheck(result, 'Nested invocation', {
+        passed: true,
+        messageContains: 'integration',
+      });
+    });
+
+    it('should not report parent context check in filtered output when env var is unset', async () => {
+      delete process.env['VV_PARENT_CONTEXT'];
+
+      await mockDoctorDefaults();
+      // In non-verbose mode, passing checks without suggestions are filtered out
+      const result = await runDoctor({ verbose: false });
+
+      const nestedCheck = result.checks.find(c => c.name === 'Nested invocation');
+      expect(nestedCheck).toBeUndefined();
+    });
+
+    it('should fail and report error when VV_PARENT_CONTEXT contains invalid JSON', async () => {
+      process.env['VV_PARENT_CONTEXT'] = 'not-valid-json';
+
+      await mockDoctorDefaults();
+      const result = await runDoctor({ verbose: true });
+
+      assertCheck(result, 'Parent context env var', {
+        passed: false,
+        messageContains: 'VV_PARENT_CONTEXT',
+      });
     });
   });
 });

--- a/packages/cli/test/commands/run.passthrough.test.ts
+++ b/packages/cli/test/commands/run.passthrough.test.ts
@@ -7,6 +7,15 @@
  * command with inherited stdio, propagating the exit code.
  *
  * These are integration tests that spawn the real built CLI (no spawn mock).
+ *
+ * NOTE on shell quoting: `vv run` invokes the inner command via `spawnCommand`
+ * with `shell: true`, so the inner command string is parsed by the host shell
+ * (cmd.exe on Windows, /bin/sh elsewhere). cmd.exe does NOT treat single quotes
+ * as quoting characters, so we use ONLY double quotes around `node -e "..."`
+ * arguments and write JS that does not need any nested string quoting (using
+ * `process.stdout.write(String.fromCharCode(...))` for literal text and
+ * `process.exit(N)` / `process.stdout.write(process.env.X || ...)` patterns
+ * for everything else).
  */
 
 import { join } from 'node:path';
@@ -35,10 +44,20 @@ function withParentCtx(ctx: object | null): Record<string, string> {
   return { [PARENT_CONTEXT_ENV]: JSON.stringify(ctx) };
 }
 
+/**
+ * Build a `node -e` command that emits the given ASCII text via
+ * `String.fromCharCode(...)`. This avoids ALL nested quoting (single OR
+ * double), so it parses identically under cmd.exe and POSIX shells.
+ */
+function nodePrintCommand(text: string, stream: 'stdout' | 'stderr' = 'stdout'): string {
+  const charCodes = [...text].map(c => c.codePointAt(0)).join(',');
+  return `node -e "process.${stream}.write(String.fromCharCode(${charCodes}))"`;
+}
+
 describe('vv run: pass-through mode (VV_PARENT_CONTEXT.capturing=true)', () => {
   it('forwards stdout from the inner command without YAML wrapping', async () => {
     const result = await executeVibeValidateCommand(
-      ['run', `node -e "console.log('HELLO')"`],
+      ['run', nodePrintCommand('HELLO')],
       { env: withParentCtx(passthroughCtx) }
     );
     expect(result.stdout).toContain('HELLO');
@@ -57,7 +76,7 @@ describe('vv run: pass-through mode (VV_PARENT_CONTEXT.capturing=true)', () => {
 
   it('forwards stderr from the inner command', async () => {
     const result = await executeVibeValidateCommand(
-      ['run', `node -e "console.error('OOPS')"`],
+      ['run', nodePrintCommand('OOPS', 'stderr')],
       { env: withParentCtx(passthroughCtx) }
     );
     expect(result.stderr).toContain('OOPS');
@@ -65,7 +84,7 @@ describe('vv run: pass-through mode (VV_PARENT_CONTEXT.capturing=true)', () => {
 
   it('does NOT pass through when no parent context (normal mode)', async () => {
     const result = await executeVibeValidateCommand(
-      ['run', `node -e "console.log('HI')"`],
+      ['run', nodePrintCommand('HI')],
       {} // no env override → no VV_PARENT_CONTEXT
     );
     // Normal mode emits YAML on stdout
@@ -76,10 +95,31 @@ describe('vv run: pass-through mode (VV_PARENT_CONTEXT.capturing=true)', () => {
     // depth=3 → child depth would be 4 → exceeds MAX_NESTED_DEPTH=3
     const tooDeepCtx = { ...passthroughCtx, depth: 3 };
     const result = await executeVibeValidateCommand(
-      ['run', `node -e "console.log('X')"`],
+      ['run', nodePrintCommand('X')],
       { env: withParentCtx(tooDeepCtx) }
     );
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toMatch(/depth exceeded/);
+  });
+
+  it('re-exports VV_PARENT_CONTEXT with depth+1 to children', async () => {
+    // Inner command prints its own VV_PARENT_CONTEXT env var to stdout.
+    // The pass-through should hand the grandchild a context with depth=2.
+    // Use process.env.VV_PARENT_CONTEXT (no quoting needed) and a literal
+    // fallback "NONE" built via String.fromCharCode to avoid shell-quote issues.
+    const fallbackChars = [...'NONE'].map(c => c.codePointAt(0)).join(',');
+    const innerCmd =
+      `node -e "process.stdout.write(process.env.VV_PARENT_CONTEXT || String.fromCharCode(${fallbackChars}))"`;
+    const result = await executeVibeValidateCommand(
+      ['run', innerCmd],
+      { env: withParentCtx(passthroughCtx) } // depth=1
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toBe('NONE');
+    const grandchildCtx = JSON.parse(result.stdout);
+    expect(grandchildCtx.depth).toBe(2);
+    expect(grandchildCtx.stepName).toBe(passthroughCtx.stepName);
+    expect(grandchildCtx.runId).toBe(passthroughCtx.runId);
+    expect(grandchildCtx.capturing).toBe(true);
   });
 });

--- a/packages/cli/test/commands/run.passthrough.test.ts
+++ b/packages/cli/test/commands/run.passthrough.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Pass-through mode tests for `vv run`.
+ *
+ * When VV_PARENT_CONTEXT is set with capturing=true (i.e. the parent vibe-validate
+ * is already capturing output), `vv run` must skip ALL of its own logic — no cache
+ * lookup, no extraction, no YAML emit, no output files — and just exec the inner
+ * command with inherited stdio, propagating the exit code.
+ *
+ * These are integration tests that spawn the real built CLI (no spawn mock).
+ */
+
+import { join } from 'node:path';
+
+import { PARENT_CONTEXT_ENV } from '@vibe-validate/core';
+import { normalizedTmpdir } from '@vibe-validate/utils';
+import { describe, it, expect } from 'vitest';
+
+import { executeVibeValidateCommand } from '../helpers/cli-execution-helpers.js';
+
+const passthroughCtx = {
+  runId: 'test-run',
+  treeHash: 'abc12345',
+  depth: 1,
+  stepName: 'test-step',
+  outputDir: join(normalizedTmpdir(), 'vv-passthrough-test'),
+  capturing: true,
+  caching: true,
+  extracting: true,
+  verbose: false,
+  forceExecution: false,
+};
+
+function withParentCtx(ctx: object | null): Record<string, string> {
+  if (ctx === null) return {};
+  return { [PARENT_CONTEXT_ENV]: JSON.stringify(ctx) };
+}
+
+describe('vv run: pass-through mode (VV_PARENT_CONTEXT.capturing=true)', () => {
+  it('forwards stdout from the inner command without YAML wrapping', async () => {
+    const result = await executeVibeValidateCommand(
+      ['run', `node -e "console.log('HELLO')"`],
+      { env: withParentCtx(passthroughCtx) }
+    );
+    expect(result.stdout).toContain('HELLO');
+    expect(result.stdout).not.toContain('exitCode:'); // No YAML
+    expect(result.stdout).not.toContain('extraction:');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('propagates non-zero exit codes', async () => {
+    const result = await executeVibeValidateCommand(
+      ['run', 'node -e "process.exit(7)"'],
+      { env: withParentCtx(passthroughCtx) }
+    );
+    expect(result.exitCode).toBe(7);
+  });
+
+  it('forwards stderr from the inner command', async () => {
+    const result = await executeVibeValidateCommand(
+      ['run', `node -e "console.error('OOPS')"`],
+      { env: withParentCtx(passthroughCtx) }
+    );
+    expect(result.stderr).toContain('OOPS');
+  });
+
+  it('does NOT pass through when no parent context (normal mode)', async () => {
+    const result = await executeVibeValidateCommand(
+      ['run', `node -e "console.log('HI')"`],
+      {} // no env override → no VV_PARENT_CONTEXT
+    );
+    // Normal mode emits YAML on stdout
+    expect(result.stdout).toContain('exitCode:');
+  });
+
+  it('errors loudly when depth would exceed MAX_NESTED_DEPTH', async () => {
+    // depth=3 → child depth would be 4 → exceeds MAX_NESTED_DEPTH=3
+    const tooDeepCtx = { ...passthroughCtx, depth: 3 };
+    const result = await executeVibeValidateCommand(
+      ['run', `node -e "console.log('X')"`],
+      { env: withParentCtx(tooDeepCtx) }
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/depth exceeded/);
+  });
+});

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -1,6 +1,8 @@
 import * as childProcess from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { join } from 'node:path';
 
+import { normalizedTmpdir } from '@vibe-validate/utils';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { runCommand } from '../../src/commands/run.js';
@@ -11,6 +13,50 @@ import { createMockChildProcess } from '../helpers/mock-helpers.js';
 vi.mock('child_process', () => ({
   spawn: vi.fn(),
 }));
+
+const VALID_PARENT_CTX = {
+  runId: 'unit-run',
+  treeHash: 'abc12345',
+  depth: 1,
+  stepName: 'test-step',
+  outputDir: join(normalizedTmpdir(), 'vv-unit'),
+  capturing: true,
+  caching: true,
+  extracting: true,
+  verbose: false,
+  forceExecution: false,
+};
+
+/**
+ * Run `vv run` with a specific VV_PARENT_CONTEXT env value, capturing the exit code.
+ * Pass `null` to clear the env, a string for raw env content, or an object that
+ * will be JSON.stringified.
+ */
+async function runWithParentCtx(
+  env: CommanderTestEnv,
+  parentCtx: object | string | null,
+  args: string[],
+): Promise<number> {
+  if (parentCtx === null) {
+    delete process.env.VV_PARENT_CONTEXT;
+  } else {
+    process.env.VV_PARENT_CONTEXT = typeof parentCtx === 'string' ? parentCtx : JSON.stringify(parentCtx);
+  }
+  runCommand(env.program);
+  try {
+    await env.program.parseAsync(['run', ...args], { from: 'user' });
+    return 0;
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.startsWith('process.exit(')) {
+      const match = /process\.exit\((\d+)\)/.exec(err.message);
+      return match ? Number.parseInt(match[1], 10) : 0;
+    }
+    if (err && typeof err === 'object' && 'exitCode' in err) {
+      return (err as { exitCode: number }).exitCode;
+    }
+    throw err;
+  }
+}
 
 describe('run command', () => {
   let env: CommanderTestEnv;
@@ -1472,6 +1518,99 @@ extraction:
         .map(call => call[0])
         .join('');
       expect(stderrCalls).toContain('package@1.0.0 test');
+    });
+  });
+
+  describe('pass-through mode (VV_PARENT_CONTEXT)', () => {
+    let savedParentCtx: string | undefined;
+
+    beforeEach(() => {
+      savedParentCtx = process.env.VV_PARENT_CONTEXT;
+    });
+
+    afterEach(() => {
+      if (savedParentCtx === undefined) delete process.env.VV_PARENT_CONTEXT;
+      else process.env.VV_PARENT_CONTEXT = savedParentCtx;
+    });
+
+    it('spawns the inner command with stdio: inherit when parent.capturing=true', async () => {
+      const mockSpawn = vi.mocked(childProcess.spawn);
+      const mockProcess = createMockChildProcess('', '', 0);
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      const exitCode = await runWithParentCtx(env, VALID_PARENT_CTX, ['echo hello']);
+
+      expect(exitCode).toBe(0);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'echo hello',
+        [],
+        expect.objectContaining({
+          shell: true,
+          stdio: ['ignore', 'inherit', 'inherit'],
+        }),
+      );
+    });
+
+    it('re-exports VV_PARENT_CONTEXT with depth+1 to children', async () => {
+      const mockSpawn = vi.mocked(childProcess.spawn);
+      const mockProcess = createMockChildProcess('', '', 0);
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      await runWithParentCtx(env, VALID_PARENT_CTX, ['echo hi']);
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      const spawnEnv = (spawnCall[2] as { env?: Record<string, string> }).env;
+      expect(spawnEnv).toBeDefined();
+      const childCtx = JSON.parse(spawnEnv!.VV_PARENT_CONTEXT);
+      expect(childCtx.depth).toBe(2);
+      expect(childCtx.runId).toBe(VALID_PARENT_CTX.runId);
+      expect(childCtx.stepName).toBe(VALID_PARENT_CTX.stepName);
+      expect(childCtx.capturing).toBe(true);
+    });
+
+    it('propagates non-zero exit code from the inner command', async () => {
+      const mockSpawn = vi.mocked(childProcess.spawn);
+      const mockProcess = createMockChildProcess('', '', 7);
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      const exitCode = await runWithParentCtx(env, VALID_PARENT_CTX, ['echo fail']);
+      expect(exitCode).toBe(7);
+    });
+
+    it('exits 2 with stderr message when VV_PARENT_CONTEXT is malformed JSON', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const exitCode = await runWithParentCtx(env, '{not valid json', ['echo x']);
+
+      expect(exitCode).toBe(2);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/Invalid VV_PARENT_CONTEXT/));
+    });
+
+    it('exits non-zero with "depth exceeded" when child depth would exceed MAX_NESTED_DEPTH', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const tooDeepCtx = { ...VALID_PARENT_CTX, depth: 3 };
+
+      const exitCode = await runWithParentCtx(env, tooDeepCtx, ['echo deep']);
+
+      expect(exitCode).not.toBe(0);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/depth exceeded/));
+    });
+
+    it('does NOT pass through when parent.capturing=false (uses normal mode)', async () => {
+      const mockSpawn = vi.mocked(childProcess.spawn);
+      const mockProcess = createMockChildProcess('output', '', 0);
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      // capturing=false means the parent isn't asking us to pass through
+      await runWithParentCtx(env, { ...VALID_PARENT_CTX, capturing: false }, ['echo test']);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'echo test',
+        [],
+        expect.objectContaining({
+          stdio: ['ignore', 'pipe', 'pipe'], // normal mode = piped
+        }),
+      );
     });
   });
 });

--- a/packages/cli/test/integration/nested-passthrough.integration.test.ts
+++ b/packages/cli/test/integration/nested-passthrough.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * End-to-end integration test for nested `vv run` pass-through.
+ *
+ * Exercises the full chain:
+ *   `vv validate` (outer, capturing) → step.command runs `vv run` (inner) →
+ *   the inner detects VV_PARENT_CONTEXT.capturing=true and execs the underlying
+ *   command with inherited stdio, no YAML wrapping, no extraction, no caching.
+ *
+ * The outer captures the REAL underlying command output and writes it to its
+ * own outputFiles. We assert the captured stdout file contains the marker
+ * emitted by the deepest command, NOT the inner's YAML/extraction summary.
+ *
+ * NOTE on shell quoting (cross-platform): the step command is executed via
+ * `spawnCommand` with `shell: true`. To avoid nested shell-quoting traps on
+ * cmd.exe (Windows) and POSIX shells alike, the step uses `vv run` with a
+ * multi-arg variadic command (no inner quotes required) that invokes a
+ * marker script we write to the temp project directory.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  initTestRepo,
+  configTestUser,
+  stageTestFiles,
+  commitTestChanges,
+} from '@vibe-validate/git';
+import { normalizedTmpdir } from '@vibe-validate/utils';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import yaml from 'yaml';
+
+import { executeVibeValidateCommand, getCliPath } from '../helpers/cli-execution-helpers.js';
+
+const MARKER = 'FROM_INNER_CMD_3F4A2B7C';
+
+/**
+ * Find an outputFiles.stdout path inside a parsed validate ValidationResult.
+ * Walks phases→steps; returns the first non-null match.
+ */
+function findStdoutFile(parsed: unknown): string | undefined {
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const phases = (parsed as { phases?: unknown }).phases;
+  if (!Array.isArray(phases)) return undefined;
+  for (const phase of phases) {
+    const steps = (phase as { steps?: unknown }).steps;
+    if (!Array.isArray(steps)) continue;
+    for (const step of steps) {
+      const stdoutPath = (step as { outputFiles?: { stdout?: string } }).outputFiles?.stdout;
+      if (typeof stdoutPath === 'string' && stdoutPath.length > 0) return stdoutPath;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract the YAML document from validate --yaml output.
+ * Output format: human progress on stderr; stdout has `---\n<yaml>\n---\n`.
+ */
+function parseValidateYaml(stdout: string): unknown {
+  const start = stdout.indexOf('---\n');
+  if (start === -1) return undefined;
+  const rest = stdout.slice(start + 4);
+  const end = rest.indexOf('\n---\n');
+  const body = end === -1 ? rest : rest.slice(0, end + 1);
+  try {
+    return yaml.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+describe('end-to-end: nested vv run pass-through', () => {
+  let testDir: string;
+  const cliPath = getCliPath('vibe-validate');
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(normalizedTmpdir(), 'vv-nested-e2e-'));
+
+    // Initialize git repo
+    initTestRepo(testDir);
+    configTestUser(testDir);
+
+    // Marker script: writes the marker to stdout and exits 0.
+    // Plain JS file → no shell quoting needed when passed as variadic args.
+    const markerScript = String.raw`// auto-generated test fixture
+process.stdout.write(${JSON.stringify(MARKER)});
+process.stdout.write('\n');
+`;
+    writeFileSync(join(testDir, 'marker.js'), markerScript);
+
+    // Config: single step that invokes `vv run` with `node marker.js` as
+    // variadic args. `vv run` reads VV_PARENT_CONTEXT from the outer and
+    // switches to pass-through mode (inherited stdio, no YAML wrapping).
+    //
+    // Using variadic args (no inner quotes) sidesteps cross-platform shell
+    // quoting issues. The step.command is parsed by the host shell once
+    // (spawnCommand shell: true), then `vv run` joins remaining argv into
+    // the inner commandString itself.
+    const config = `validation:
+  phases:
+    - name: Nested
+      parallel: false
+      steps:
+        - name: inner-vv-run
+          command: node ${JSON.stringify(cliPath)} run node marker.js
+`;
+    writeFileSync(join(testDir, 'vibe-validate.config.yaml'), config);
+
+    // Dummy file so commit produces a stable tree hash.
+    writeFileSync(join(testDir, 'README.md'), '# nested-passthrough test\n');
+
+    stageTestFiles(testDir);
+    commitTestChanges(testDir, 'init');
+  });
+
+  afterEach(() => {
+    if (testDir && existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it(
+    'outer captures real underlying command output (not inner YAML)',
+    async () => {
+      // --debug forces outputFiles to be created even for passing steps so we
+      // can inspect what the outer captured. We also defensively strip any
+      // VV_PARENT_CONTEXT inherited from the test runner (the outer must be
+      // the top of the chain).
+      const childEnv: Record<string, string> = {};
+      for (const [key, value] of Object.entries(process.env)) {
+        if (key === 'VV_PARENT_CONTEXT') continue;
+        if (value !== undefined) childEnv[key] = value;
+      }
+
+      const result = await executeVibeValidateCommand(
+        ['validate', '--yaml', '--debug', '--force', '--no-lock'],
+        { cwd: testDir, timeout: 60_000, env: childEnv }
+      );
+
+      // The outer validate must succeed — inner pass-through forwards the
+      // marker script's exit code 0 verbatim.
+      expect(result.exitCode).toBe(0);
+
+      // Parse the YAML document from stdout and locate the captured stdout
+      // file the outer wrote for the step. The outer pipes the inner's
+      // stdio into its own buffers (not back out to its own stdout/stderr),
+      // so the marker should NOT appear in result.stdout/stderr — only in
+      // the outer's captured outputFiles.
+      const parsed = parseValidateYaml(result.stdout);
+      expect(parsed).toBeDefined();
+      const stdoutFile = findStdoutFile(parsed);
+      expect(stdoutFile, 'expected step.outputFiles.stdout in YAML output').toBeDefined();
+      expect(existsSync(stdoutFile!)).toBe(true);
+
+      const captured = readFileSync(stdoutFile!, 'utf-8');
+
+      // The captured file must hold the REAL inner command output, NOT the
+      // inner `vv run`'s YAML wrapper / extraction summary.
+      expect(captured).toContain(MARKER);
+      expect(captured).not.toMatch(/^---$/m); // no YAML doc separator
+      expect(captured).not.toContain('extraction:');
+      expect(captured).not.toContain('exitCode:');
+    },
+    60_000
+  );
+});

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,3 +137,14 @@ export {
   OutputLineSchema,
   CapturedOutputSchema,
 } from './output-capture-schema.js';
+
+// Export ParentContext schema and utilities
+export {
+  PARENT_CONTEXT_ENV,
+  MAX_NESTED_DEPTH,
+  ParentContextSchema,
+  readParentContext,
+  buildChildContext,
+  serializeForEnv,
+} from './parent-context.js';
+export type { ParentContext, ChildContextInput } from './parent-context.js';

--- a/packages/core/src/parent-context.ts
+++ b/packages/core/src/parent-context.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+export const PARENT_CONTEXT_ENV = 'VV_PARENT_CONTEXT';
+export const MAX_NESTED_DEPTH = 3;
+
+export const ParentContextSchema = z.object({
+  runId: z.string().min(1),
+  treeHash: z.string().min(1),
+  depth: z.number().int().nonnegative(),
+  stepName: z.string().min(1),
+  phaseName: z.string().min(1).optional(),
+  outputDir: z.string().min(1),
+  capturing: z.boolean(),
+  caching: z.boolean(),
+  extracting: z.boolean(),
+  verbose: z.boolean(),
+  forceExecution: z.boolean(),
+}).strict();
+
+export type ParentContext = z.infer<typeof ParentContextSchema>;
+
+export interface ChildContextInput {
+  runId: string;
+  treeHash: string;
+  stepName: string;
+  phaseName?: string;
+  outputDir: string;
+  verbose: boolean;
+  forceExecution: boolean;
+}
+
+export function readParentContext(): ParentContext | null {
+  const raw = process.env[PARENT_CONTEXT_ENV];
+  if (!raw) return null;
+  try {
+    return ParentContextSchema.parse(JSON.parse(raw));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid ${PARENT_CONTEXT_ENV}: ${detail}. ` +
+      `Unset ${PARENT_CONTEXT_ENV} and retry.`
+    );
+  }
+}
+
+export function buildChildContext(
+  parent: ParentContext | null,
+  input: ChildContextInput
+): ParentContext {
+  const depth = (parent?.depth ?? 0) + 1;
+  if (depth > MAX_NESTED_DEPTH) {
+    throw new Error(
+      `Nested vibe-validate depth exceeded ${MAX_NESTED_DEPTH} — likely a recursive ` +
+      `'vibe-validate run' wrapper inside a package.json script invoked from 'vibe-validate validate'. ` +
+      `Remove the inner 'vibe-validate run' wrapper; the outer already handles capture, extraction, and caching.`
+    );
+  }
+  return {
+    runId: input.runId,
+    treeHash: input.treeHash,
+    depth,
+    stepName: input.stepName,
+    ...(input.phaseName ? { phaseName: input.phaseName } : {}),
+    outputDir: input.outputDir,
+    capturing: true,
+    caching: true,
+    extracting: true,
+    verbose: input.verbose,
+    forceExecution: input.forceExecution,
+  };
+}
+
+export function serializeForEnv(ctx: ParentContext): string {
+  return JSON.stringify(ctx);
+}

--- a/packages/core/src/process-utils.ts
+++ b/packages/core/src/process-utils.ts
@@ -178,15 +178,22 @@ export function spawnCommand(
     env?: Record<string, string>;
     /** Working directory (defaults to current directory) */
     cwd?: string;
+    /** Stdio mode. 'pipe' (default) captures stdout/stderr; 'inherit' attaches to parent's streams. */
+    stdio?: 'pipe' | 'inherit';
   }
 ): ChildProcess {
+  const stdio: ['ignore', 'pipe' | 'inherit', 'pipe' | 'inherit'] =
+    options?.stdio === 'inherit'
+      ? ['ignore', 'inherit', 'inherit']
+      : ['ignore', 'pipe', 'pipe'];
+
   // SECURITY: shell: true required for shell operators (&&, ||, |) and cross-platform compatibility.
   // Commands from user config files only (same trust as npm scripts). See SECURITY.md for full threat model.
   // NOSONAR - Intentional shell execution of user-defined commands
   // eslint-disable-next-line sonarjs/os-command
   return spawn(command, options?.args ?? [], {
     shell: true,
-    stdio: ['ignore', 'pipe', 'pipe'], // No stdin (prevent hangs), capture stdout/stderr
+    stdio,
     timeout: options?.timeout,
     // detached: true only on Unix - Windows doesn't pipe stdio correctly when detached
     detached: options?.detached ?? (process.platform !== 'win32'),

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -44,6 +44,79 @@ import type {
 import { parseVibeValidateOutput } from './run-output-parser.js';
 
 /**
+ * Convert a step name into a filesystem-safe slug for output directory paths.
+ *
+ * Replaces any non-alphanumeric character with `-`. Used to build per-step
+ * output directories under the run-scoped temp directory.
+ *
+ * @param name - The step name to slugify
+ * @returns A filesystem-safe slug
+ *
+ * @internal
+ */
+function slugifyStepName(name: string): string {
+  return name.replaceAll(/[^a-z0-9]/gi, '-');
+}
+
+/**
+ * Build a stable per-validation-run identifier from the current ISO timestamp
+ * and the leading 8 characters of the working tree hash.
+ *
+ * Used as `ParentContext.runId` and as the directory key under
+ * `${getTempDir('steps')}/<runId>/<step-slug>`.
+ *
+ * @param treeHash - Current git working tree hash
+ * @returns Run identifier string (e.g. `2026-04-24T12-00-00-000Z-abcd1234`)
+ *
+ * @internal
+ */
+function makeRunId(treeHash: string): string {
+  return `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${treeHash.slice(0, 8)}`;
+}
+
+/**
+ * Resolve the per-step output directory and build the spawn environment with
+ * VV_PARENT_CONTEXT injected for nested vibe-validate invocations.
+ *
+ * Used by both the sequential and parallel step execution paths. Returns the
+ * resolved `outputDir` so the caller can pass it back to the file-creation
+ * helpers, ensuring `ParentContext.outputDir` and the actual file location
+ * are always identical.
+ *
+ * @param args - Step, base env, parent context, runId, treeHash, optional phase
+ * @returns Step env (with VV_PARENT_CONTEXT) and the resolved outputDir
+ *
+ * @internal
+ */
+function buildStepEnv(args: {
+  step: ValidationStep;
+  baseEnv: Record<string, string>;
+  parent: ReturnType<typeof readParentContext>;
+  runId: string;
+  treeHash: string;
+  phaseName?: string;
+  verbose: boolean;
+}): { env: Record<string, string>; outputDir: string } {
+  const outputDir = join(getTempDir('steps'), args.runId, slugifyStepName(args.step.name));
+  const childCtx = buildChildContext(args.parent, {
+    runId: args.runId,
+    treeHash: args.treeHash,
+    stepName: args.step.name,
+    ...(args.phaseName ? { phaseName: args.phaseName } : {}),
+    outputDir,
+    verbose: args.verbose,
+    forceExecution: process.env.VV_FORCE_EXECUTION === '1',
+  });
+  return {
+    env: {
+      ...args.baseEnv,
+      [PARENT_CONTEXT_ENV]: serializeForEnv(childCtx),
+    },
+    outputDir,
+  };
+}
+
+/**
  * Determine if a step should be skipped based on its runScope and the current environment.
  *
  * - `runScope: 'ci'` — only runs in CI, skipped locally
@@ -487,7 +560,12 @@ function parseAndLogCacheStatus(
 }
 
 /**
- * Create output files for step
+ * Create output files for step.
+ *
+ * Writes the captured stdout/stderr/combined streams under `outputDir`.
+ * The caller is responsible for resolving `outputDir` (typically the same
+ * directory advertised in `ParentContext.outputDir`), so a nested child
+ * process can predict where its outer-captured files will live.
  */
 async function createStepOutputFiles(
   stepName: string,
@@ -495,12 +573,12 @@ async function createStepOutputFiles(
   stderr: string,
   combinedLines: Array<{ ts: string; stream: 'stdout' | 'stderr'; line: string }>,
   verbose: boolean,
-  log: (_msg: string) => void
+  log: (_msg: string) => void,
+  outputDir: string
 ): Promise<{ stdout?: string; stderr?: string; combined?: string } | undefined> {
   try {
     const treeHashResult = await getGitTreeHash();
     const treeHash = treeHashResult.hash;
-    const outputDir = getTempDir('steps');
     await ensureDir(outputDir);
 
     // Generate unique filenames with tree hash and timestamp
@@ -541,7 +619,8 @@ async function processStepOutput(
   stdout: string,
   stderr: string,
   combinedLines: Array<{ ts: string; stream: 'stdout' | 'stderr'; line: string }>,
-  options: ProcessOutputOptions
+  options: ProcessOutputOptions,
+  outputDir: string
 ): Promise<{
   extraction?: ErrorExtractorResult;
   isCachedResult?: boolean;
@@ -569,7 +648,7 @@ async function processStepOutput(
   // Create output files if needed
   const shouldCreateFiles = exitCode !== 0 || options.debug;
   if (shouldCreateFiles && !outputFiles) {
-    outputFiles = await createStepOutputFiles(stepName, stdout, stderr, combinedLines, options.verbose, options.log);
+    outputFiles = await createStepOutputFiles(stepName, stdout, stderr, combinedLines, options.verbose, options.log, outputDir);
   }
 
   return { extraction, isCachedResult, outputFiles };
@@ -698,22 +777,17 @@ async function executeSingleStep(options: ExecuteSingleStepOptions): Promise<{ o
   // treeHash/runId when provided by runValidation (avoids extra git calls and
   // keeps the runId stable across all steps in this validation run).
   const resolvedTreeHash = treeHash ?? (await getGitTreeHash()).hash;
-  const resolvedRunId = runId ?? `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${resolvedTreeHash.slice(0, 8)}`;
-  const stepOutputDir = join(getTempDir('steps'), resolvedRunId, step.name.replaceAll(/[^a-z0-9]/gi, '-'));
+  const resolvedRunId = runId ?? makeRunId(resolvedTreeHash);
   const parent = readParentContext();
-  const childCtx = buildChildContext(parent, {
+  const { env: stepEnv, outputDir: stepOutputDir } = buildStepEnv({
+    step,
+    baseEnv: env,
+    parent,
     runId: resolvedRunId,
     treeHash: resolvedTreeHash,
-    stepName: step.name,
     ...(phaseName ? { phaseName } : {}),
-    outputDir: stepOutputDir,
     verbose,
-    forceExecution: process.env.VV_FORCE_EXECUTION === '1',
   });
-  const stepEnv = {
-    ...env,
-    [PARENT_CONTEXT_ENV]: serializeForEnv(childCtx),
-  };
 
   const proc = spawnCommand(step.command, { env: stepEnv, cwd: resolvedCwd });
 
@@ -753,7 +827,8 @@ async function executeSingleStep(options: ExecuteSingleStepOptions): Promise<{ o
     stdout,
     stderr,
     combinedLines,
-    { verbose, debug, log }
+    { verbose, debug, log },
+    stepOutputDir
   );
 
   // Create step result (build without type annotation to let TS infer)
@@ -954,24 +1029,18 @@ export async function runStepsInParallel(
   // to a single getGitTreeHash() call (used when runStepsInParallel is invoked directly).
   const parentCtx = readParentContext();
   const sharedTreeHash = options.treeHash ?? (await getGitTreeHash()).hash;
-  const sharedRunId =
-    options.runId ?? `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${sharedTreeHash.slice(0, 8)}`;
-  const stepEnvs = new Map<string, Record<string, string>>();
+  const sharedRunId = options.runId ?? makeRunId(sharedTreeHash);
+  const stepEnvs = new Map<string, { env: Record<string, string>; outputDir: string }>();
   for (const step of steps) {
-    const stepOutputDir = join(getTempDir('steps'), sharedRunId, step.name.replaceAll(/[^a-z0-9]/gi, '-'));
-    const childCtx = buildChildContext(parentCtx, {
+    stepEnvs.set(step.name, buildStepEnv({
+      step,
+      baseEnv: env,
+      parent: parentCtx,
       runId: sharedRunId,
       treeHash: sharedTreeHash,
-      stepName: step.name,
       ...(phaseName ? { phaseName } : {}),
-      outputDir: stepOutputDir,
       verbose,
-      forceExecution: process.env.VV_FORCE_EXECUTION === '1',
-    });
-    stepEnvs.set(step.name, {
-      ...env,
-      [PARENT_CONTEXT_ENV]: serializeForEnv(childCtx),
-    });
+    }));
   }
 
   const results = await Promise.allSettled(
@@ -1037,7 +1106,13 @@ export async function runStepsInParallel(
 
         // Resolve cwd relative to git root (if specified)
         const resolvedCwd = step.cwd ? resolveGitRelativePath(step.cwd) : undefined;
-        const stepEnv = stepEnvs.get(step.name) ?? env;
+        const stepEnvEntry = stepEnvs.get(step.name);
+        const stepEnv = stepEnvEntry?.env ?? env;
+        // Output directory advertised in ParentContext.outputDir; the inline
+        // file-creation block below writes to this same directory so the
+        // advertised location matches the actual filesystem location.
+        const stepOutputDir =
+          stepEnvEntry?.outputDir ?? join(getTempDir('steps'), sharedRunId, slugifyStepName(step.name));
         const proc = spawnCommand(step.command, {
           env: stepEnv,
           cwd: resolvedCwd,
@@ -1154,8 +1229,9 @@ export async function runStepsInParallel(
               try {
                 const treeHashResult = await getGitTreeHash();
                 const treeHash = treeHashResult.hash;
-                const outputDir = getTempDir('steps');
-                await ensureDir(outputDir);
+                // Use the same outputDir we advertised in ParentContext.outputDir
+                // so the advertised location matches where the files actually live.
+                await ensureDir(stepOutputDir);
 
                 const writePromises: Promise<void>[] = [];
 
@@ -1166,16 +1242,16 @@ export async function runStepsInParallel(
 
                 // Write stdout.log (only if non-empty) using shared utility
                 const { file: stdoutFile, promise: stdoutPromise } =
-                  createLogFileWrite(stdout, outputDir, stdoutFilename);
+                  createLogFileWrite(stdout, stepOutputDir, stdoutFilename);
                 if (stdoutPromise) writePromises.push(stdoutPromise);
 
                 // Write stderr.log (only if non-empty) using shared utility
                 const { file: stderrFile, promise: stderrPromise } =
-                  createLogFileWrite(stderr, outputDir, stderrFilename);
+                  createLogFileWrite(stderr, stepOutputDir, stderrFilename);
                 if (stderrPromise) writePromises.push(stderrPromise);
 
                 // Write combined.jsonl (always - timestamped interleaved output)
-                const combinedFile = join(outputDir, combinedFilename);
+                const combinedFile = join(stepOutputDir, combinedFilename);
                 const combinedContent = createCombinedJsonl(combinedLines);
                 writePromises.push(writeFile(combinedFile, combinedContent, 'utf-8'));
 
@@ -1354,7 +1430,7 @@ export async function runValidation(config: ValidationConfig): Promise<Validatio
   const treeHashResult = await getGitTreeHash();
   const currentTreeHash = treeHashResult.hash;
   // Stable per-validation-run identifier (used for ParentContext.runId / outputDir layout)
-  const runId = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${currentTreeHash.slice(0, 8)}`;
+  const runId = makeRunId(currentTreeHash);
 
   // Note: Caching is now handled at the CLI layer via git notes
   // (see packages/cli/src/commands/validate.ts and @vibe-validate/history)

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -29,6 +29,12 @@ import {
   createLogFileWrite,
   createCombinedJsonl,
 } from './fs-utils.js';
+import {
+  buildChildContext,
+  PARENT_CONTEXT_ENV,
+  readParentContext,
+  serializeForEnv,
+} from './parent-context.js';
 import { stopProcessGroup, spawnCommand, resolveGitRelativePath } from './process-utils.js';
 import type {
   ValidationResult,
@@ -169,6 +175,10 @@ interface StepExecutionOptions {
   debug?: boolean;
   /** Previous validation run for retry-failed functionality */
   previousRun?: ValidationConfig['previousRun'];
+  /** Pre-computed git tree hash for the current run (reused across all steps) */
+  treeHash?: string;
+  /** Pre-computed run id for the current run (reused across all steps) */
+  runId?: string;
 }
 
 /**
@@ -577,6 +587,12 @@ interface ExecuteSingleStepOptions {
   maxNameLength: number;
   log: (_msg: string) => void;
   previousRun?: ValidationConfig['previousRun'];
+  /** Containing phase name (propagated into VV_PARENT_CONTEXT) */
+  phaseName?: string;
+  /** Pre-computed git tree hash for the current run */
+  treeHash?: string;
+  /** Pre-computed run id for the current run */
+  runId?: string;
 }
 
 /**
@@ -652,7 +668,7 @@ function tryUseCachedResult(
 }
 
 async function executeSingleStep(options: ExecuteSingleStepOptions): Promise<{ output: string; stepResult: StepResult }> {
-  const { step, env, verbose, yaml, debug, maxNameLength, log, previousRun } = options;
+  const { step, env, verbose, yaml, debug, maxNameLength, log, previousRun, phaseName, treeHash, runId } = options;
   const paddedName = step.name.padEnd(maxNameLength);
 
   // Check if step should be skipped based on runScope
@@ -677,7 +693,29 @@ async function executeSingleStep(options: ExecuteSingleStepOptions): Promise<{ o
   const startTime = Date.now();
   // Resolve cwd relative to git root (if specified)
   const resolvedCwd = step.cwd ? resolveGitRelativePath(step.cwd) : undefined;
-  const proc = spawnCommand(step.command, { env, cwd: resolvedCwd });
+
+  // Build per-step ParentContext and inject into child env. Reuse the run-level
+  // treeHash/runId when provided by runValidation (avoids extra git calls and
+  // keeps the runId stable across all steps in this validation run).
+  const resolvedTreeHash = treeHash ?? (await getGitTreeHash()).hash;
+  const resolvedRunId = runId ?? `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${resolvedTreeHash.slice(0, 8)}`;
+  const stepOutputDir = join(getTempDir('steps'), resolvedRunId, step.name.replaceAll(/[^a-z0-9]/gi, '-'));
+  const parent = readParentContext();
+  const childCtx = buildChildContext(parent, {
+    runId: resolvedRunId,
+    treeHash: resolvedTreeHash,
+    stepName: step.name,
+    ...(phaseName ? { phaseName } : {}),
+    outputDir: stepOutputDir,
+    verbose,
+    forceExecution: process.env.VV_FORCE_EXECUTION === '1',
+  });
+  const stepEnv = {
+    ...env,
+    [PARENT_CONTEXT_ENV]: serializeForEnv(childCtx),
+  };
+
+  const proc = spawnCommand(step.command, { env: stepEnv, cwd: resolvedCwd });
 
   // Use object accumulators for mutable references
   const stdoutAccumulator = { value: '' };
@@ -785,6 +823,8 @@ export async function runStepsSequentially(
     yaml = false,
     debug = false,
     previousRun,
+    treeHash,
+    runId,
   } = options;
   // When yaml mode is on, write progress to stderr to keep stdout clean
   const log = yaml ?
@@ -808,6 +848,9 @@ export async function runStepsSequentially(
       maxNameLength,
       log,
       previousRun,
+      phaseName,
+      treeHash,
+      runId,
     });
 
     outputs.set(step.name, output);
@@ -906,6 +949,31 @@ export async function runStepsInParallel(
 
   const ignoreStopErrors = () => { /* Process may have already exited */ };
 
+  // Pre-compute per-step ParentContext env so the spawn executor below stays synchronous.
+  // Reuse run-level treeHash/runId when provided by runValidation; otherwise fall back
+  // to a single getGitTreeHash() call (used when runStepsInParallel is invoked directly).
+  const parentCtx = readParentContext();
+  const sharedTreeHash = options.treeHash ?? (await getGitTreeHash()).hash;
+  const sharedRunId =
+    options.runId ?? `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${sharedTreeHash.slice(0, 8)}`;
+  const stepEnvs = new Map<string, Record<string, string>>();
+  for (const step of steps) {
+    const stepOutputDir = join(getTempDir('steps'), sharedRunId, step.name.replaceAll(/[^a-z0-9]/gi, '-'));
+    const childCtx = buildChildContext(parentCtx, {
+      runId: sharedRunId,
+      treeHash: sharedTreeHash,
+      stepName: step.name,
+      ...(phaseName ? { phaseName } : {}),
+      outputDir: stepOutputDir,
+      verbose,
+      forceExecution: process.env.VV_FORCE_EXECUTION === '1',
+    });
+    stepEnvs.set(step.name, {
+      ...env,
+      [PARENT_CONTEXT_ENV]: serializeForEnv(childCtx),
+    });
+  }
+
   const results = await Promise.allSettled(
     steps.map(step =>
       new Promise<{ step: ValidationStep; output: string; durationSecs: number }>((resolve, reject) => {
@@ -969,8 +1037,9 @@ export async function runStepsInParallel(
 
         // Resolve cwd relative to git root (if specified)
         const resolvedCwd = step.cwd ? resolveGitRelativePath(step.cwd) : undefined;
+        const stepEnv = stepEnvs.get(step.name) ?? env;
         const proc = spawnCommand(step.command, {
-          env,
+          env: stepEnv,
           cwd: resolvedCwd,
         });
 
@@ -1284,6 +1353,8 @@ export async function runValidation(config: ValidationConfig): Promise<Validatio
   // Get current working tree hash (deterministic, content-based)
   const treeHashResult = await getGitTreeHash();
   const currentTreeHash = treeHashResult.hash;
+  // Stable per-validation-run identifier (used for ParentContext.runId / outputDir layout)
+  const runId = `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${currentTreeHash.slice(0, 8)}`;
 
   // Note: Caching is now handled at the CLI layer via git notes
   // (see packages/cli/src/commands/validate.ts and @vibe-validate/history)
@@ -1340,6 +1411,8 @@ export async function runValidation(config: ValidationConfig): Promise<Validatio
         developerFeedback: config.developerFeedback ?? false,
         debug: config.debug ?? false,
         previousRun: config.previousRun,
+        treeHash: currentTreeHash,
+        runId,
       }
     );
     const phaseDurationMs = Date.now() - phaseStartTime;

--- a/packages/core/test/parent-context.test.ts
+++ b/packages/core/test/parent-context.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  ParentContextSchema,
+  readParentContext,
+  buildChildContext,
+  serializeForEnv,
+  PARENT_CONTEXT_ENV,
+  MAX_NESTED_DEPTH,
+} from '../src/parent-context.js';
+
+describe('ParentContext', () => {
+  const validCtx = {
+    runId: 'run-abc',
+    treeHash: 'deadbeef',
+    depth: 1,
+    stepName: 'Integration tests',
+    phaseName: 'Integration Tests',
+    // eslint-disable-next-line sonarjs/publicly-writable-directories -- Test fixture data only
+    outputDir: '/tmp/vv/runs/run-abc/steps/integration-tests',
+    capturing: true,
+    caching: true,
+    extracting: true,
+    verbose: false,
+    forceExecution: false,
+  };
+
+  describe('ParentContextSchema', () => {
+    it('parses a valid context', () => {
+      expect(() => ParentContextSchema.parse(validCtx)).not.toThrow();
+    });
+
+    it('rejects unknown fields (strict)', () => {
+      const withExtra = { ...validCtx, somethingElse: 'x' };
+      expect(() => ParentContextSchema.parse(withExtra)).toThrow();
+    });
+
+    it('rejects negative depth', () => {
+      expect(() => ParentContextSchema.parse({ ...validCtx, depth: -1 })).toThrow();
+    });
+
+    it('makes phaseName optional', () => {
+      const withoutPhase = Object.fromEntries(
+        Object.entries(validCtx).filter(([key]) => key !== 'phaseName')
+      );
+      expect(() => ParentContextSchema.parse(withoutPhase)).not.toThrow();
+    });
+  });
+
+  describe('readParentContext', () => {
+    let savedEnv: string | undefined;
+    beforeEach(() => { savedEnv = process.env[PARENT_CONTEXT_ENV]; });
+    afterEach(() => {
+      if (savedEnv === undefined) delete process.env[PARENT_CONTEXT_ENV];
+      else process.env[PARENT_CONTEXT_ENV] = savedEnv;
+    });
+
+    it('returns null when env var is not set', () => {
+      delete process.env[PARENT_CONTEXT_ENV];
+      expect(readParentContext()).toBeNull();
+    });
+
+    it('returns parsed context when env var is valid JSON', () => {
+      process.env[PARENT_CONTEXT_ENV] = JSON.stringify(validCtx);
+      expect(readParentContext()).toEqual(validCtx);
+    });
+
+    it('throws on malformed JSON', () => {
+      process.env[PARENT_CONTEXT_ENV] = '{not json';
+      expect(() => readParentContext()).toThrow(/Invalid VV_PARENT_CONTEXT/);
+    });
+
+    it('throws on schema mismatch (unknown field)', () => {
+      process.env[PARENT_CONTEXT_ENV] = JSON.stringify({ ...validCtx, foo: 'bar' });
+      expect(() => readParentContext()).toThrow(/Invalid VV_PARENT_CONTEXT/);
+    });
+  });
+
+  describe('buildChildContext', () => {
+    const stepInput = {
+      runId: 'run-abc',
+      treeHash: 'deadbeef',
+      stepName: 'Integration tests',
+      phaseName: 'Integration Tests',
+      // eslint-disable-next-line sonarjs/publicly-writable-directories -- Test fixture data only
+      outputDir: '/tmp/vv/x',
+      verbose: false,
+      forceExecution: false,
+    };
+
+    it('starts at depth 1 when no parent', () => {
+      const ctx = buildChildContext(null, stepInput);
+      expect(ctx.depth).toBe(1);
+    });
+
+    it('increments depth when parent exists', () => {
+      const ctx = buildChildContext(validCtx, stepInput);
+      expect(ctx.depth).toBe(validCtx.depth + 1);
+    });
+
+    it('throws when depth would exceed MAX_NESTED_DEPTH', () => {
+      const deepParent = { ...validCtx, depth: MAX_NESTED_DEPTH };
+      expect(() => buildChildContext(deepParent, stepInput)).toThrow(/depth exceeded/);
+    });
+
+    it('sets capabilities to true for outer-handled work', () => {
+      const ctx = buildChildContext(null, stepInput);
+      expect(ctx.capturing).toBe(true);
+      expect(ctx.caching).toBe(true);
+      expect(ctx.extracting).toBe(true);
+    });
+  });
+
+  describe('serializeForEnv', () => {
+    it('roundtrips through JSON.parse + schema parse', () => {
+      const serialized = serializeForEnv(validCtx);
+      expect(ParentContextSchema.parse(JSON.parse(serialized))).toEqual(validCtx);
+    });
+  });
+});

--- a/packages/core/test/process-utils.test.ts
+++ b/packages/core/test/process-utils.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { stopProcessGroup, getGitRoot, resolveGitRelativePath } from '../src/process-utils.js';
+import { stopProcessGroup, getGitRoot, resolveGitRelativePath, spawnCommand } from '../src/process-utils.js';
 
 describe('process-utils', () => {
   describe('stopProcessGroup', () => {
@@ -292,6 +292,24 @@ describe('process-utils', () => {
       const path = 'packages/cli';
       const resolved = resolveGitRelativePath(path);
       expect(resolved).toContain('packages/cli');
+    });
+  });
+
+  describe('spawnCommand stdio option', () => {
+    it('defaults to piped stdio (existing behavior)', () => {
+      const proc = spawnCommand('node -e "process.exit(0)"');
+      expect(proc.stdout).not.toBeNull();
+      expect(proc.stderr).not.toBeNull();
+      proc.kill();
+    });
+
+    it('uses inherit when stdio: "inherit" is passed', () => {
+      const proc = spawnCommand('node -e "process.exit(0)"', { stdio: 'inherit' });
+      // With inherit, stdout/stderr on the ChildProcess are null because
+      // they're attached directly to the parent's streams.
+      expect(proc.stdout).toBeNull();
+      expect(proc.stderr).toBeNull();
+      proc.kill();
     });
   });
 });

--- a/packages/core/test/runner.test.ts
+++ b/packages/core/test/runner.test.ts
@@ -4,6 +4,7 @@
  
 import type { ChildProcess } from 'node:child_process';
 import { readFileSync, unlinkSync, existsSync, readdirSync, rmdirSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { ValidationStep } from '@vibe-validate/config';
@@ -2069,6 +2070,64 @@ rawOutput: |
 
       const logOutput = consoleSpy.mock.calls.map(call => String(call[0])).join('\n');
       expect(logOutput).toContain('skipped (local-only)');
+    });
+  });
+
+  describe('ParentContext propagation', () => {
+    it('sets VV_PARENT_CONTEXT in spawned step environment (sequential)', async () => {
+      const config: ValidationConfig = {
+        phases: [{
+          name: 'TestPhase',
+          parallel: false,
+          steps: [{
+            name: 'echo-context',
+            command: 'node -e "process.stdout.write(process.env.VV_PARENT_CONTEXT || \'NONE\')"',
+          }],
+        }],
+        env: {},
+        verbose: false,
+        yaml: false,
+        debug: true,
+      };
+
+      const result = await runValidation(config);
+
+      const stepOutput = result.phases[0].steps[0];
+      expect(stepOutput.passed).toBe(true);
+      const captured = await readFile(stepOutput.outputFiles!.stdout!, 'utf-8');
+      const parsed = JSON.parse(captured);
+      expect(parsed.stepName).toBe('echo-context');
+      expect(parsed.phaseName).toBe('TestPhase');
+      expect(parsed.depth).toBe(1);
+      expect(parsed.capturing).toBe(true);
+    });
+
+    it('sets VV_PARENT_CONTEXT in spawned step environment (parallel)', async () => {
+      const config: ValidationConfig = {
+        phases: [{
+          name: 'ParallelPhase',
+          parallel: true,
+          steps: [{
+            name: 'echo-context-parallel',
+            command: 'node -e "process.stdout.write(process.env.VV_PARENT_CONTEXT || \'NONE\')"',
+          }],
+        }],
+        env: {},
+        verbose: false,
+        yaml: false,
+        debug: true,
+      };
+
+      const result = await runValidation(config);
+
+      const stepOutput = result.phases[0].steps[0];
+      expect(stepOutput.passed).toBe(true);
+      const captured = await readFile(stepOutput.outputFiles!.stdout!, 'utf-8');
+      const parsed = JSON.parse(captured);
+      expect(parsed.stepName).toBe('echo-context-parallel');
+      expect(parsed.phaseName).toBe('ParallelPhase');
+      expect(parsed.depth).toBe(1);
+      expect(parsed.capturing).toBe(true);
     });
   });
 });

--- a/packages/core/test/runner.test.ts
+++ b/packages/core/test/runner.test.ts
@@ -2092,7 +2092,7 @@ rawOutput: |
 
       const result = await runValidation(config);
 
-      const stepOutput = result.phases[0].steps[0];
+      const stepOutput = result.phases![0].steps[0];
       expect(stepOutput.passed).toBe(true);
       const captured = await readFile(stepOutput.outputFiles!.stdout!, 'utf-8');
       const parsed = JSON.parse(captured);
@@ -2120,7 +2120,7 @@ rawOutput: |
 
       const result = await runValidation(config);
 
-      const stepOutput = result.phases[0].steps[0];
+      const stepOutput = result.phases![0].steps[0];
       expect(stepOutput.passed).toBe(true);
       const captured = await readFile(stepOutput.outputFiles!.stdout!, 'utf-8');
       const parsed = JSON.parse(captured);

--- a/packages/core/test/runner.test.ts
+++ b/packages/core/test/runner.test.ts
@@ -2100,6 +2100,9 @@ rawOutput: |
       expect(parsed.phaseName).toBe('TestPhase');
       expect(parsed.depth).toBe(1);
       expect(parsed.capturing).toBe(true);
+      // Advertised ParentContext.outputDir must match where the outer-captured
+      // step output files actually live (Task 3 / I1: alignment).
+      expect(stepOutput.outputFiles!.stdout!.startsWith(parsed.outputDir)).toBe(true);
     });
 
     it('sets VV_PARENT_CONTEXT in spawned step environment (parallel)', async () => {
@@ -2128,6 +2131,9 @@ rawOutput: |
       expect(parsed.phaseName).toBe('ParallelPhase');
       expect(parsed.depth).toBe(1);
       expect(parsed.capturing).toBe(true);
+      // Advertised ParentContext.outputDir must match where the outer-captured
+      // step output files actually live (Task 3 / I1: alignment).
+      expect(stepOutput.outputFiles!.stdout!.startsWith(parsed.outputDir)).toBe(true);
     });
   });
 });

--- a/packages/core/test/runner.test.ts
+++ b/packages/core/test/runner.test.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 
 import type { ValidationStep } from '@vibe-validate/config';
 import { getGitTreeHash } from '@vibe-validate/git';
-import { mkdirSyncReal, normalizedTmpdir } from '@vibe-validate/utils';
+import { mkdirSyncReal, normalizedTmpdir, toForwardSlash } from '@vibe-validate/utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
@@ -95,6 +95,50 @@ async function testSignalHandler(signalName: 'SIGTERM' | 'SIGINT'): Promise<void
 
   // Verify process.exit was called
   expect(processExitSpy).toHaveBeenCalled();
+}
+
+/**
+ * Run a single-step validation that echoes VV_PARENT_CONTEXT to stdout, then
+ * read back the captured context for assertion.
+ */
+async function runEchoContextStep(parallel: boolean, phaseName: string, stepName: string) {
+  const config: ValidationConfig = {
+    phases: [{
+      name: phaseName,
+      parallel,
+      steps: [{
+        name: stepName,
+        command: 'node -e "process.stdout.write(process.env.VV_PARENT_CONTEXT || \'NONE\')"',
+      }],
+    }],
+    env: {},
+    verbose: false,
+    yaml: false,
+    debug: true,
+  };
+
+  const result = await runValidation(config);
+  const phases = result.phases;
+  if (!phases) throw new Error('expected phases on result');
+  const stepOutput = phases[0].steps[0];
+  const stdoutPath = stepOutput.outputFiles?.stdout;
+  if (!stdoutPath) throw new Error('expected outputFiles.stdout on step');
+  const captured = await readFile(stdoutPath, 'utf-8');
+  return { stepOutput, parsed: JSON.parse(captured), stdoutPath };
+}
+
+function expectParentContext(
+  result: Awaited<ReturnType<typeof runEchoContextStep>>,
+  expected: { stepName: string; phaseName: string },
+) {
+  expect(result.stepOutput.passed).toBe(true);
+  expect(result.parsed.stepName).toBe(expected.stepName);
+  expect(result.parsed.phaseName).toBe(expected.phaseName);
+  expect(result.parsed.depth).toBe(1);
+  expect(result.parsed.capturing).toBe(true);
+  // Advertised ParentContext.outputDir must match where the outer-captured
+  // step output files actually live (Task 3 / I1: alignment).
+  expect(toForwardSlash(result.stdoutPath).startsWith(toForwardSlash(result.parsed.outputDir))).toBe(true);
 }
 
 describe('runner', () => {
@@ -2075,65 +2119,13 @@ rawOutput: |
 
   describe('ParentContext propagation', () => {
     it('sets VV_PARENT_CONTEXT in spawned step environment (sequential)', async () => {
-      const config: ValidationConfig = {
-        phases: [{
-          name: 'TestPhase',
-          parallel: false,
-          steps: [{
-            name: 'echo-context',
-            command: 'node -e "process.stdout.write(process.env.VV_PARENT_CONTEXT || \'NONE\')"',
-          }],
-        }],
-        env: {},
-        verbose: false,
-        yaml: false,
-        debug: true,
-      };
-
-      const result = await runValidation(config);
-
-      const stepOutput = result.phases![0].steps[0];
-      expect(stepOutput.passed).toBe(true);
-      const captured = await readFile(stepOutput.outputFiles!.stdout!, 'utf-8');
-      const parsed = JSON.parse(captured);
-      expect(parsed.stepName).toBe('echo-context');
-      expect(parsed.phaseName).toBe('TestPhase');
-      expect(parsed.depth).toBe(1);
-      expect(parsed.capturing).toBe(true);
-      // Advertised ParentContext.outputDir must match where the outer-captured
-      // step output files actually live (Task 3 / I1: alignment).
-      expect(stepOutput.outputFiles!.stdout!.startsWith(parsed.outputDir)).toBe(true);
+      const result = await runEchoContextStep(false, 'TestPhase', 'echo-context');
+      expectParentContext(result, { stepName: 'echo-context', phaseName: 'TestPhase' });
     });
 
     it('sets VV_PARENT_CONTEXT in spawned step environment (parallel)', async () => {
-      const config: ValidationConfig = {
-        phases: [{
-          name: 'ParallelPhase',
-          parallel: true,
-          steps: [{
-            name: 'echo-context-parallel',
-            command: 'node -e "process.stdout.write(process.env.VV_PARENT_CONTEXT || \'NONE\')"',
-          }],
-        }],
-        env: {},
-        verbose: false,
-        yaml: false,
-        debug: true,
-      };
-
-      const result = await runValidation(config);
-
-      const stepOutput = result.phases![0].steps[0];
-      expect(stepOutput.passed).toBe(true);
-      const captured = await readFile(stepOutput.outputFiles!.stdout!, 'utf-8');
-      const parsed = JSON.parse(captured);
-      expect(parsed.stepName).toBe('echo-context-parallel');
-      expect(parsed.phaseName).toBe('ParallelPhase');
-      expect(parsed.depth).toBe(1);
-      expect(parsed.capturing).toBe(true);
-      // Advertised ParentContext.outputDir must match where the outer-captured
-      // step output files actually live (Task 3 / I1: alignment).
-      expect(stepOutput.outputFiles!.stdout!.startsWith(parsed.outputDir)).toBe(true);
+      const result = await runEchoContextStep(true, 'ParallelPhase', 'echo-context-parallel');
+      expectParentContext(result, { stepName: 'echo-context-parallel', phaseName: 'ParallelPhase' });
     });
   });
 });

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.4",
+  "version": "0.19.5-rc.1",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -21,13 +21,14 @@ import { defineConfig } from 'vitest/config';
  *
  * All tests must be cross-platform (Windows + Unix).
  *
- * INCLUDED TESTS (89 total):
+ * INCLUDED TESTS (90 total):
  * - packaging.system.test.ts: npm package integrity (14 tests, ALL SKIPPED - see test file for reason)
  * - subdirectory-behavior.system.test.ts: CLI from subdirectories (26 tests)
  * - tree-hash.integration.test.ts: git tree hash with real repos (11 tests)
  * - history-recording.test.ts: git notes history tracking (3 tests)
  * - cache-manager.integration.test.ts: real filesystem cache operations (9 tests)
  * - watch-pr-extraction.integration.test.ts: extractor quality validation (6 tests)
+ * - nested-passthrough.integration.test.ts: end-to-end nested vv run pass-through (1 test)
  * - run.integration.test.ts: run command with real extractors (34 tests)
  */
 const isWindows = process.platform === 'win32';
@@ -47,6 +48,7 @@ export default defineConfig({
       'packages/cli/test/integration/history-recording.test.ts',
       'packages/cli/test/integration/cache-manager.integration.test.ts',
       'packages/cli/test/integration/watch-pr-extraction.integration.test.ts',
+      'packages/cli/test/integration/nested-passthrough.integration.test.ts',
       'packages/cli/test/commands/run.integration.test.ts',
     ],
     testTimeout: 60000, // 60 seconds per test (increased for Windows CI resource constraints)


### PR DESCRIPTION
## Summary

When a \`package.json\` test script wraps a tool with \`vibe-validate run\` (e.g. \`\"test:integration\": \"vibe-validate run \\\"vitest ...\\\"\"\`) and is invoked from \`vibe-validate validate\`, the inner \`vv run\` now switches to **pass-through mode** automatically:

- Inherits the parent's stdio (no double-capture)
- Skips its own caching, error extraction, and YAML output
- Propagates the underlying command's exit code

The outer captures the real underlying tool's output (vitest, eslint, etc.) instead of an inner YAML summary, so error extraction runs on actual data and \`vv watch-pr\` can recover failures from CI logs.

Signaled via the new \`VV_PARENT_CONTEXT\` environment variable, set automatically by the parent. A depth cap of 3 fails loudly on recursive misconfiguration. \`vv doctor\` reports nested invocations.

### Why this matters

Documented in \`/tmp/vibe-validate-debug-report.md\` from vibe-agent-toolkit PR #93: a CI-only test failure was undebuggable remotely because the inner \`vv run\` captured vitest's stdout/stderr to ephemeral \`/tmp/vibe-validate/steps/...\` files on the GHA runner, emitted only a YAML summary to its own stdout, and the outer extractor saw an empty stream → reported \`totalErrors: 0\` despite \`exitCode: 1\`. The captured files vanished when the runner was destroyed. \`vv watch-pr\` had nothing to recover. Pass-through routes the underlying command's output directly to the outer, so the failure ends up in the GHA log where it belongs.

## What's in this PR

**Core (\`@vibe-validate/core\`):**
- \`parent-context.ts\` — Zod schema, env reader/writer, depth-cap enforcement
- \`spawnCommand\` extended with \`stdio: 'pipe' | 'inherit'\` option
- \`runner.ts\` injects \`VV_PARENT_CONTEXT\` into every spawned step (sequential and parallel paths)
- \`runId\`, \`buildStepEnv\`, \`slugifyStepName\`, \`makeRunId\` helpers extracted; \`outputDir\` field now matches actual file location

**CLI (\`@vibe-validate/cli\`):**
- \`vv run\` reads \`VV_PARENT_CONTEXT\` at entry; if \`capturing: true\`, takes pass-through branch
- Re-exports context with \`depth+1\` for grandchildren
- Shared \`resolveCwdWithinGitRoot\` helper between pass-through and existing execution paths (Windows-safe path validation)
- \`vv doctor\` surfaces nested invocation, fails loudly on malformed env

**Tests:**
- 13 unit tests for ParentContext schema/reader/builder
- 2 propagation tests in runner (sequential + parallel)
- 6 pass-through tests in CLI (including grandchild depth+1, depth-exceeded error)
- 3 doctor tests (nested/unset/malformed)
- End-to-end integration test that exercises the WHOLE chain — real \`vv validate\` against a temp config that uses \`vv run\` inside a step, asserts outer captures real command output (not YAML)

**Docs:**
- New section in \`docs/skills/vv-watch-pr/SKILL.md\` (the user-facing CI debugging skill)
- CHANGELOG \`[Unreleased]\` entry

## Test plan
- [x] \`pnpm validate\` clean (8 steps across 2 phases, last run via pre-commit hook)
- [x] All 11 commits authored test-first (TDD per CLAUDE.md)
- [x] Two-stage review (spec compliance + code quality) on each substantive task
- [x] Depth cap fires correctly at depth=4 with remediation hint
- [x] Normal mode (no env var) provably unaffected — existing run.ts logic emits YAML as before
- [ ] Manual verification on vibe-agent-toolkit-shaped config: vitest failure output reaches GHA logs (next step after merge)

🤖 Generated with [Claude Code](https://claude.ai/code)