### PR TITLE
fix: scrub GIT_* through full worker chain (v0.19.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-05-12
+
 ### Added
 
 - **Nested `vv run` pass-through** — When a `package.json` script wraps a tool with `vibe-validate run` and is invoked from `vibe-validate validate`, the inner `vv run` now switches automatically to pass-through mode: it inherits the parent's stdio, propagates the exit code, and skips its own capture/extract/cache. The outer captures the real underlying tool's output (vitest, eslint, etc.) instead of an inner YAML summary, so error extraction runs on actual data and `vv watch-pr` can recover failures from CI logs. A depth cap of 3 fails loudly on recursive misconfiguration. Signaled via the new `VV_PARENT_CONTEXT` environment variable, set automatically by the parent.
@@ -21,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Prevent silent corruption of the parent repository when validation steps shell out to `git`.** ([#157](https://github.com/jdutton/vibe-validate/issues/157))
 
-  When vv runs as a git pre-commit hook, git sets `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, and related vars on the hook process. These vars were inherited by every subprocess vv spawned. Inside those subprocesses, `GIT_*` vars override the `cwd` passed to git — so a validation step (typically a test) that creates a temp git repo with `mkdtempSync` + `cwd: <tmpdir>` and runs `git init` / `git commit` / `git config` would **silently operate on the parent repository's `.git/index` and branch refs instead**.
+  When vv runs as a git pre-commit hook, git sets `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, and related vars on the hook process. These vars were inherited by every subprocess vv spawned, including multi-process step chains like `npm run test → vitest → fork(worker)`. Inside those subprocesses, `GIT_*` vars override the `cwd` passed to git — so a validation step (typically a test) that creates a temp git repo with `mkdtempSync` + `cwd: <tmpdir>` and runs `git init` / `git commit` / `git config` would **silently operate on the parent repository's `.git/index` and branch refs instead**.
 
-  vv now strips a focused **blacklist** of dangerous `GIT_*` env vars from the env passed to spawned validation steps — the exact set of vars that can redirect git operations to a different repository, override repository discovery, load alternate git configuration, or alter the history view. Everything else `GIT_*` (identity, editor, SSH/credentials, tracing, pager) is inherited normally. User-provided env via config-level `env:` or per-step `env:` always wins on top, so any step that legitimately needs a stripped var can re-add it explicitly.
+  vv now strips a focused **blacklist** of dangerous `GIT_*` env vars at two layers: (1) the runner adapter strips them when snapshotting `process.env` into the runner config, and (2) `spawnCommand` strips them from the *final merged* spawn env (parent ∪ caller-provided), so no caller can accidentally re-inject one via `options.env`. Together this guarantees no dangerous `GIT_*` reaches a step subprocess or anything it spawns. Everything else `GIT_*` (identity, editor, SSH/credentials, tracing, pager) is inherited normally.
 
   **Stripped:** `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_NAMESPACE`, `GIT_CEILING_DIRECTORIES`, `GIT_DISCOVERY_ACROSS_FILESYSTEM`, `GIT_CONFIG`, `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`, `GIT_CONFIG_NOSYSTEM`, `GIT_CONFIG_COUNT`, all numbered `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*`, `GIT_NOTES_REF`, `GIT_SHALLOW_FILE`, `GIT_GRAFT_FILE`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/utils/runner-adapter.ts
+++ b/packages/cli/src/utils/runner-adapter.ts
@@ -6,6 +6,7 @@
 
 import type { VibeValidateConfig } from '@vibe-validate/config';
 import type { ValidationConfig, ValidationPhase, ValidationStep, PhaseResult, StepResult } from '@vibe-validate/core';
+import { stripGitEnv } from '@vibe-validate/core';
 import chalk from 'chalk';
 
 import type { AgentContext } from './context-detector.js';
@@ -29,13 +30,13 @@ export function createRunnerConfig(
   config: VibeValidateConfig,
   options: RunnerOptions
 ): ValidationConfig {
-  // Convert process.env to Record<string, string> by filtering out undefined values
-  const envVars: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) {
-      envVars[key] = value;
-    }
-  }
+  // Convert process.env to Record<string, string> for the runner's `env`.
+  // Strip dangerous GIT_* vars (GIT_DIR, GIT_INDEX_FILE, …) here so they
+  // never enter the runner pipeline. Without this scrub, the runner would
+  // pass them as `options.env` to spawnCommand, where they'd be re-injected
+  // on top of the spawn-boundary scrub. spawnCommand also re-scrubs the
+  // merged env defensively (belt + suspenders).
+  const envVars = stripGitEnv(process.env);
 
   // Choose callbacks based on verbosity
   const callbacks = options.verbose

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.5-rc.2'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.5'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/cli/test/helpers/cli-execution-helpers.ts
+++ b/packages/cli/test/helpers/cli-execution-helpers.ts
@@ -9,10 +9,11 @@
  */
 
 import type { ExecSyncOptions } from 'node:child_process';
-import { rmSync, existsSync } from 'node:fs';
+import { rmSync, existsSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { executeGitCommand } from '@vibe-validate/git';
 import { normalizePath, safeExecFromString, normalizedTmpdir, mkdirSyncReal } from '@vibe-validate/utils';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -306,6 +307,53 @@ export function setupTestDir(prefix: string): string {
   const targetDir = join(tmpBase, `${prefix}-${Date.now()}`);
   return mkdirSyncReal(targetDir, { recursive: true });
 }
+
+/**
+ * Create a temporary test directory pre-initialized as a minimal git repo.
+ *
+ * Initializes `main` branch and configures a dummy user.email / user.name so
+ * subsequent `git commit` calls succeed in CI environments that lack a global
+ * git identity. The returned directory is a normal `setupTestDir` output, so
+ * `cleanupTestDir` cleans it up as usual.
+ *
+ * If `options.files` is provided, the files are written, staged, and
+ * committed as an initial commit (so the repo has a tree hash that vv can
+ * resolve). Use `options.commitMessage` to override the default message.
+ *
+ * @param prefix - Directory name prefix
+ * @param options - Optional initial files to commit
+ * @returns Normalized path to the created git repo
+ */
+export function setupTestGitRepo(
+  prefix: string,
+  options?: { files?: Record<string, string>; commitMessage?: string },
+): string {
+  const testDir = setupTestDir(prefix);
+  executeGitCommand(['-C', testDir, 'init', '-b', 'main'], { suppressStderr: true });
+  executeGitCommand(['-C', testDir, 'config', 'user.email', 'test@example.com'], { suppressStderr: true });
+  executeGitCommand(['-C', testDir, 'config', 'user.name', 'Test'], { suppressStderr: true });
+
+  if (options?.files) {
+    for (const [relPath, content] of Object.entries(options.files)) {
+      writeFileSync(join(testDir, relPath), content);
+    }
+    executeGitCommand(['-C', testDir, 'add', '.'], { suppressStderr: true });
+    executeGitCommand(
+      ['-C', testDir, 'commit', '-m', options.commitMessage ?? 'init'],
+      { suppressStderr: true },
+    );
+  }
+  return testDir;
+}
+
+/**
+ * Absolute path to the built CLI bin (`packages/cli/dist/bin.js`).
+ *
+ * Resolved relative to this helper file so it works regardless of which
+ * integration test imports it. Used by `executeCommandWithSeparateStreams`
+ * and `executeWrapperCommand` callers that spawn the real CLI.
+ */
+export const cliBinPath = join(__dirname, '../../dist/bin.js');
 
 /**
  * Clean up a temporary test directory

--- a/packages/cli/test/integration/git-env-scrub-worker-chain.integration.test.ts
+++ b/packages/cli/test/integration/git-env-scrub-worker-chain.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * End-to-end integration test: GIT_* env scrubbing through multi-process chains
+ *
+ * Verifies that GIT_DIR is stripped not just at the immediate spawn boundary,
+ * but throughout the full validation execution chain:
+ *
+ *   vv validate → spawnCommand → step subprocess → forked worker
+ *
+ * Background: PR #158 added GIT_* scrubbing inside `spawnCommand`. It worked
+ * for `vv run`, which passes nothing dangerous via `options.env`. It did NOT
+ * cover `vv validate`, because the runner adapter (`createRunnerConfig`)
+ * copies all of `process.env` into the runner config's `env`, which the
+ * runner then passes as `options.env` to `spawnCommand`. The merge order at
+ * the spawn boundary (`{ ...scrubbedParentEnv, ...options.env }`) let
+ * GIT_DIR back in via the second spread, so step subprocesses (and any
+ * workers they forked) still saw GIT_DIR. This test catches that gap.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { cleanupTestDir, cliBinPath, setupTestGitRepo } from '../helpers/cli-execution-helpers.js';
+import { executeCommandWithSeparateStreams } from '../helpers/test-command-runner.js';
+
+// worker-check.js: forks a child, then asserts in the child that none of the
+// dangerous GIT_* vars are set. Exits non-zero if any leaked through. This
+// exercises the multi-process chain: vv → spawnCommand → node → fork(worker).
+const WORKER_CHECK_JS = `'use strict';
+const { fork } = require('node:child_process');
+
+if (process.argv[2] === 'worker') {
+  const dangerous = ['GIT_DIR', 'GIT_INDEX_FILE', 'GIT_WORK_TREE'];
+  for (const key of dangerous) {
+    if (process.env[key]) {
+      console.error('LEAK: worker ' + key + '=' + process.env[key]);
+      process.exit(2);
+    }
+  }
+  process.exit(0);
+}
+
+const worker = fork(__filename, ['worker'], { stdio: 'inherit' });
+worker.on('exit', (code) => process.exit(code === null ? 1 : code));
+`;
+
+const VIBE_VALIDATE_CONFIG = `validation:
+  phases:
+    - name: worker-check
+      steps:
+        - name: worker-check
+          command: node worker-check.js
+`;
+
+describe('GIT_* env scrubbing through multi-process chains (end-to-end)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = setupTestGitRepo('vv-git-scrub-worker', {
+      files: {
+        'worker-check.js': WORKER_CHECK_JS,
+        'vibe-validate.config.yaml': VIBE_VALIDATE_CONFIG,
+        '.gitignore': 'node_modules\n',
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanupTestDir(testDir);
+  });
+
+  it('strips GIT_DIR/GIT_INDEX_FILE through full validate → step → fork worker chain', async () => {
+    const result = await executeCommandWithSeparateStreams(
+      cliBinPath,
+      ['validate', '--force'],
+      {
+        cwd: testDir,
+        env: {
+          GIT_DIR: '/fake/parent/.git',
+          GIT_INDEX_FILE: '/fake/parent/index',
+        },
+      },
+    );
+
+    // If vv exits 0, no LEAK was emitted by the worker.
+    // If non-zero, dump diagnostics so the failure is actionable.
+    expect(
+      result.exitCode,
+      `vv validate exited ${result.exitCode}.\nstderr:\n${result.stderr}\nstdout:\n${result.stdout}`,
+    ).toBe(0);
+    // Defensive: even if exit code is somehow 0, ensure no LEAK message slipped through.
+    expect(result.stderr + result.stdout).not.toContain('LEAK:');
+  }, 60000);
+});

--- a/packages/cli/test/integration/git-env-scrub.integration.test.ts
+++ b/packages/cli/test/integration/git-env-scrub.integration.test.ts
@@ -9,39 +9,16 @@
  * step subprocesses the steps can see the wrong git context. Task 2
  * (spawnCommand) scrubs them; this test proves the scrub works end-to-end.
  */
-import { writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-import { executeGitCommand } from '@vibe-validate/git';
-import { normalizedTmpdir, mkdirSyncReal } from '@vibe-validate/utils';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-import { cleanupTestDir } from '../helpers/cli-execution-helpers.js';
+import { cleanupTestDir, cliBinPath, setupTestGitRepo } from '../helpers/cli-execution-helpers.js';
 import { executeCommandWithSeparateStreams } from '../helpers/test-command-runner.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// Resolved from packages/cli/test/integration/ → packages/cli/dist/bin.js
-const binPath = join(__dirname, '../../dist/bin.js');
 
 describe('GIT_* env scrubbing (end-to-end)', () => {
   let testDir: string;
 
   beforeEach(() => {
-    testDir = mkdirSyncReal(
-      join(normalizedTmpdir(), `vv-git-scrub-test-${Date.now()}`),
-      { recursive: true },
-    );
-
-    // Minimal git repo so vv has something to work with
-    executeGitCommand(['-C', testDir, 'init', '-b', 'main'], { suppressStderr: true });
-    executeGitCommand(['-C', testDir, 'config', 'user.email', 'test@example.com'], { suppressStderr: true });
-    executeGitCommand(['-C', testDir, 'config', 'user.name', 'Test'], { suppressStderr: true });
-    writeFileSync(join(testDir, 'README.md'), 'test');
-    executeGitCommand(['-C', testDir, 'add', '.'], { suppressStderr: true });
-    executeGitCommand(['-C', testDir, 'commit', '-m', 'init'], { suppressStderr: true });
+    testDir = setupTestGitRepo('vv-git-scrub-test', { files: { 'README.md': 'test' } });
   });
 
   afterEach(() => {
@@ -59,7 +36,7 @@ describe('GIT_* env scrubbing (end-to-end)', () => {
     // them — Windows will mangle the script even though it's inside double quotes.
     const stepCmd = `node -e "console.log('GIT_DIR=' + (process.env.GIT_DIR || '<unset>')); console.log('GIT_INDEX_FILE=' + (process.env.GIT_INDEX_FILE || '<unset>'))"`;
 
-    const result = await executeCommandWithSeparateStreams(binPath, ['run', '--verbose', stepCmd], {
+    const result = await executeCommandWithSeparateStreams(cliBinPath, ['run', '--verbose', stepCmd], {
       cwd: testDir,
       env: {
         GIT_DIR: '/fake/parent/.git',

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,7 @@ export {
   captureCommandOutput,
   getGitRoot,
   resolveGitRelativePath,
+  stripGitEnv,
   type CaptureCommandOptions,
 } from './process-utils.js';
 

--- a/packages/core/src/process-utils.ts
+++ b/packages/core/src/process-utils.ts
@@ -267,12 +267,20 @@ export function spawnCommand(
       ? ['ignore', 'inherit', 'inherit']
       : ['ignore', 'pipe', 'pipe'];
 
-  // SAFETY: Scrub GIT_* vars from process.env before passing to child.
-  // When vv runs as a git pre-commit hook, git sets GIT_DIR / GIT_INDEX_FILE /
-  // GIT_WORK_TREE on the hook process. Those vars override `cwd` in any child
-  // that runs git, which would silently corrupt the parent repository if a step
-  // shells out to git against a temp directory. See docs/skills/vibe-validate/git-hook-safety.md.
-  const scrubbedParentEnv = stripGitEnv(process.env);
+  // SAFETY: Scrub GIT_* vars from the final spawn env. When vv runs as a git
+  // pre-commit hook, git sets GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE on the
+  // hook process. Those vars override `cwd` in any child that runs git, which
+  // would silently corrupt the parent repository if a step shells out to git
+  // against a temp directory. See docs/skills/vibe-validate/git-hook-safety.md.
+  //
+  // The scrub is applied to the MERGED env (parent ∪ caller-provided), not
+  // just the parent — otherwise a caller passing `options.env` derived from
+  // `process.env` (the runner does this) would silently re-inject GIT_* on
+  // top of the parent scrub via the second spread.
+  const mergedEnv = options?.env
+    ? { ...process.env, ...options.env }
+    : process.env;
+  const scrubbedEnv = stripGitEnv(mergedEnv);
   // SECURITY: shell: true required for shell operators (&&, ||, |) and cross-platform compatibility.
   // Commands from user config files only (same trust as npm scripts). See SECURITY.md for full threat model.
   // NOSONAR - Intentional shell execution of user-defined commands
@@ -283,7 +291,7 @@ export function spawnCommand(
     timeout: options?.timeout,
     // detached: true only on Unix - Windows doesn't pipe stdio correctly when detached
     detached: options?.detached ?? (process.platform !== 'win32'),
-    env: options?.env ? { ...scrubbedParentEnv, ...options.env } : scrubbedParentEnv,
+    env: scrubbedEnv,
     cwd: options?.cwd,
   });
 }

--- a/packages/core/test/process-utils.test.ts
+++ b/packages/core/test/process-utils.test.ts
@@ -369,9 +369,15 @@ describe('process-utils', () => {
       expect(env.PATH).toBe(true);
     });
 
-    it('lets caller-provided env override the scrub (re-add path)', async () => {
+    it('also strips dangerous GIT_* from caller-provided options.env (worker chain fix)', async () => {
+      // The runner adapter passes a snapshot of process.env as options.env to
+      // spawnCommand. Without scrubbing the merged env, dangerous GIT_* vars
+      // would be re-injected on top of the parent scrub and leak through to
+      // step subprocesses (and their forked workers). The fix scrubs the
+      // FINAL merged env, so even caller-provided GIT_* is dropped.
       const env = await captureChildEnv({ GIT_DIR: '/restored', CUSTOM: 'yes' });
-      expect(env.GIT_DIR).toBe('/restored');
+      expect(env.GIT_DIR).toBeUndefined();
+      // Non-dangerous caller-provided vars are preserved.
       expect(env.CUSTOM).toBe('yes');
     });
 

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.5-rc.2",
+  "version": "0.19.5",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Closes the `GIT_*` env scrub gap that PR #158 missed: the validation path (vv validate → step subprocess → forked worker) still leaked `GIT_DIR` despite the spawn-boundary scrub.
- Two-layer fix: `createRunnerConfig` strips dangerous `GIT_*` at the source when snapshotting `process.env`; `spawnCommand` now strips the **final merged** env (parent ∪ options.env), so no caller can re-inject via `options.env`.
- Bumps stable release to **v0.19.5** (consolidates rc.1/rc.2/rc.3).

## Why the original fix missed this

`spawnCommand` correctly scrubbed `process.env` at the boundary. But the runner's `createRunnerConfig` snapshots `process.env` (including `GIT_DIR`) into the runner config's `env`, and the runner passes that to `spawnCommand` as `options.env`. The original merge ordered `{ ...scrubbedParent, ...options.env }` — the second spread re-injected `GIT_DIR` on top of the scrub. The pre-existing integration test only exercised `vv run` (which passes nothing dangerous via `options.env`), so the gap went undetected.

Adopter confirmed `GIT_DIR` reaching vitest workers via `vv pre-commit → spawnCommand → npm run test → vitest → fork(worker)` on v0.19.5-rc.2. Adopter has confirmed v0.19.5-rc.3 works.

## What's new

- New end-to-end integration test: `packages/cli/test/integration/git-env-scrub-worker-chain.integration.test.ts` — spawns `vv validate` with `GIT_DIR=/fake/parent/.git`, runs a step that `fork()`s a worker, asserts the worker doesn't see `GIT_DIR`. FAILS on main, PASSES with the fix.
- Existing single-process scrub test still passes.
- Existing unit test that locked in the old (buggy) "caller-provided env overrides scrub" behavior updated to assert the new (correct) behavior — dangerous `GIT_*` are stripped from the final merged env regardless of caller.
- Shared test helper `setupTestGitRepo` extracted (with optional initial-commit files) to keep both integration tests under the duplication threshold.

## Test plan

- [x] New integration test FAILS on main, PASSES on fix branch (verified locally)
- [x] Existing single-process `vv run` scrub test still passes
- [x] All 180 core unit tests pass
- [x] `pnpm validate` clean (8 steps, 2 phases)
- [x] Adopter confirmed fix via `VV_ROOT_DIR={cwd}` install
- [ ] CI green
- [ ] After merge: `pnpm pre-release` on main, then `git tag v0.19.5`

🤖 Generated with [Claude Code](https://claude.ai/code)