### PR TITLE
fix(git): rebase-aware tracking divergence check

### DIFF
--- a/.github/.jscpd-baseline.json
+++ b/.github/.jscpd-baseline.json
@@ -543,7 +543,7 @@
     {
       "format": "typescript",
       "lines": 11,
-      "fragment": ";\n\n      const mockCommitCount = '1';\n\n      // Mock git package functions instead of safeExecSync\n      vi.spyOn(gitPackage, 'getDiffStats').mockReturnValue(mockDiffOutput);\n      vi.spyOn(gitPackage, 'getCommitCount').mockReturnValue(mockCommitCount);\n\n      const changes = await fetcher.fetchFileChanges(123);\n\n      expect(changes.top_files?",
+      "fragment": ";\n\n      const mockCommitCount = '1';\n\n      // Mock git package functions instead of safeExecSync\n      vi.spyOn(gitPackage, 'getDiffStats').mockReturnValue(mockDiffOutput);\n      vi.spyOn(gitPackage, 'getCommitCount').mockReturnValue(mockCommitCount);\n\n      const changes = await fetcher.fetchFileChanges(123, 'main');\n\n      expect(changes.top_files?",
       "tokens": 0,
       "firstFile": {
         "name": "packages/cli/test/services/github-fetcher.test.ts",
@@ -552,12 +552,12 @@
         "startLoc": {
           "line": 534,
           "column": 9,
-          "position": 3910
+          "position": 3916
         },
         "endLoc": {
           "line": 544,
           "column": 2,
-          "position": 3986
+          "position": 3995
         }
       },
       "secondFile": {
@@ -567,19 +567,19 @@
         "startLoc": {
           "line": 519,
           "column": 2,
-          "position": 3784
+          "position": 3787
         },
         "endLoc": {
           "line": 528,
           "column": 2,
-          "position": 3859
+          "position": 3865
         }
       }
     },
     {
       "format": "typescript",
       "lines": 10,
-      "fragment": ";\n\n      // Mock git package functions instead of safeExecSync\n      vi.spyOn(gitPackage, 'getDiffStats').mockReturnValue(mockDiffOutput);\n      vi.spyOn(gitPackage, 'getCommitCount').mockReturnValue(mockCommitCount);\n\n      const changes = await fetcher.fetchFileChanges(123);\n\n      expect(changes).toEqual({\n        files_changed: 0",
+      "fragment": ";\n\n      // Mock git package functions instead of safeExecSync\n      vi.spyOn(gitPackage, 'getDiffStats').mockReturnValue(mockDiffOutput);\n      vi.spyOn(gitPackage, 'getCommitCount').mockReturnValue(mockCommitCount);\n\n      const changes = await fetcher.fetchFileChanges(123, 'main');\n\n      expect(changes).toEqual({\n        files_changed: 0",
       "tokens": 0,
       "firstFile": {
         "name": "packages/cli/test/services/github-fetcher.test.ts",
@@ -588,12 +588,12 @@
         "startLoc": {
           "line": 549,
           "column": 4,
-          "position": 4040
+          "position": 4049
         },
         "endLoc": {
           "line": 558,
           "column": 2,
-          "position": 4113
+          "position": 4125
         }
       },
       "secondFile": {
@@ -608,115 +608,7 @@
         "endLoc": {
           "line": 505,
           "column": 2,
-          "position": 3552
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 9,
-      "fragment": ";\n\n      const result = await detector.detectAndExtract(check, logs);\n\n      expect(result).toBeDefined();\n      expect(result?.summary).toBe('2 test failure(s)');\n      expect(result?.totalErrors).toBe(2);\n      expect(result?.errors).toHaveLength(2);\n      expect(result?.errors",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/cli/test/services/extraction-mode-detector.test.ts",
-        "start": 172,
-        "end": 180,
-        "startLoc": {
-          "line": 172,
-          "column": 101,
-          "position": 825
-        },
-        "endLoc": {
-          "line": 180,
-          "column": 7,
-          "position": 911
-        }
-      },
-      "secondFile": {
-        "name": "packages/cli/test/services/extraction-mode-detector.test.ts",
-        "start": 59,
-        "end": 67,
-        "startLoc": {
-          "line": 59,
-          "column": 2,
-          "position": 210
-        },
-        "endLoc": {
-          "line": 67,
-          "column": 9,
-          "position": 296
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 9,
-      "fragment": ";\n\n      const result = await detector.detectAndExtract(check, logs);\n\n      expect(result).toBeDefined();\n      expect(result?.summary).toBe('2 test failure(s)');\n      expect(result?.totalErrors).toBe(2);\n      expect(result?.errors).toHaveLength(2);\n    }",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/cli/test/services/extraction-mode-detector.test.ts",
-        "start": 484,
-        "end": 492,
-        "startLoc": {
-          "line": 484,
-          "column": 2,
-          "position": 2867
-        },
-        "endLoc": {
-          "line": 492,
-          "column": 2,
-          "position": 2948
-        }
-      },
-      "secondFile": {
-        "name": "packages/cli/test/services/extraction-mode-detector.test.ts",
-        "start": 59,
-        "end": 67,
-        "startLoc": {
-          "line": 59,
-          "column": 2,
-          "position": 210
-        },
-        "endLoc": {
-          "line": 67,
-          "column": 7,
-          "position": 291
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 13,
-      "fragment": ",\n        totalErrors: 1,\n        errors: [{ message: 'Error' }],\n      });\n\n      const result = await detector.detectAndExtract(check, logs);\n\n      // Should fall back to non-matrix mode\n      expect(result).toBeDefined();\n      expect(autoDetectAndExtract).toHaveBeenCalled();\n    });\n  });\n}",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/cli/test/services/extraction-mode-detector.test.ts",
-        "start": 543,
-        "end": 555,
-        "startLoc": {
-          "line": 543,
-          "column": 16,
-          "position": 3355
-        },
-        "endLoc": {
-          "line": 555,
-          "column": 2,
-          "position": 3442
-        }
-      },
-      "secondFile": {
-        "name": "packages/cli/test/services/extraction-mode-detector.test.ts",
-        "start": 134,
-        "end": 147,
-        "startLoc": {
-          "line": 134,
-          "column": 10,
-          "position": 646
-        },
-        "endLoc": {
-          "line": 147,
-          "column": 9,
-          "position": 735
+          "position": 3555
         }
       }
     },
@@ -866,94 +758,22 @@
     },
     {
       "format": "typescript",
-      "lines": 8,
-      "fragment": "));\n\n      snapshotCommand(env.program);\n      const exitCode = await runSnapshotCommand();\n      expect(exitCode).toBe(0);\n\n      const output = getLogOutput();\n      expect(output.some(call => call.includes('Validation Status:') && call.includes('Failed'",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/cli/test/commands/snapshot.test.ts",
-        "start": 146,
-        "end": 153,
-        "startLoc": {
-          "line": 146,
-          "column": 6,
-          "position": 1504
-        },
-        "endLoc": {
-          "line": 153,
-          "column": 9,
-          "position": 1581
-        }
-      },
-      "secondFile": {
-        "name": "packages/cli/test/commands/snapshot.test.ts",
-        "start": 133,
-        "end": 140,
-        "startLoc": {
-          "line": 133,
-          "column": 5,
-          "position": 1342
-        },
-        "endLoc": {
-          "line": 140,
-          "column": 9,
-          "position": 1419
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 11,
-      "fragment": "));\n      snapshotCommand(env.program);\n\n      const exitCode = await runSnapshotCommand();\n      expect(exitCode).toBe(1);\n      expect(console.error).toHaveBeenCalledWith(\n        expect.stringContaining('Failed to get snapshot'),\n        expect.any(Error)\n      );\n    });\n  }",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/cli/test/commands/snapshot.test.ts",
-        "start": 198,
-        "end": 208,
-        "startLoc": {
-          "line": 198,
-          "column": 25,
-          "position": 2104
-        },
-        "endLoc": {
-          "line": 208,
-          "column": 2,
-          "position": 2182
-        }
-      },
-      "secondFile": {
-        "name": "packages/cli/test/commands/snapshot.test.ts",
-        "start": 185,
-        "end": 196,
-        "startLoc": {
-          "line": 185,
-          "column": 23,
-          "position": 1982
-        },
-        "endLoc": {
-          "line": 196,
-          "column": 3,
-          "position": 2061
-        }
-      }
-    },
-    {
-      "format": "typescript",
       "lines": 11,
       "fragment": ": vi.fn(),\n  };\n});\n\n// Mock the config loader\nvi.mock('../../src/utils/config-loader.js', async () => {\n  const actual = await vi.importActual<typeof configLoader>('../../src/utils/config-loader.js');\n  return {\n    ...actual,\n    loadConfig: vi.fn(),\n    loadConfigWithDir",
       "tokens": 0,
       "firstFile": {
         "name": "packages/cli/test/commands/pre-commit.test.ts",
-        "start": 58,
-        "end": 68,
+        "start": 59,
+        "end": 69,
         "startLoc": {
-          "line": 58,
+          "line": 59,
           "column": 19,
-          "position": 565
+          "position": 576
         },
         "endLoc": {
-          "line": 68,
+          "line": 69,
           "column": 18,
-          "position": 645
+          "position": 656
         }
       },
       "secondFile": {
@@ -1113,186 +933,6 @@
           "line": 103,
           "column": 43,
           "position": 753
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 11,
-      "fragment": "),\n}));\n\nvi.mock('fs', () => ({\n  writeFileSync: vi.fn(),\n  unlinkSync: vi.fn(),\n}));\n\nvi.mock('../src/reader.js', () => ({\n  readHistoryNote: vi.fn(() => Promise.resolve(null)),\n  listHistoryTreeHashes",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/history/test/integration.test.ts",
-        "start": 34,
-        "end": 44,
-        "startLoc": {
-          "line": 34,
-          "column": 2,
-          "position": 315
-        },
-        "endLoc": {
-          "line": 44,
-          "column": 22,
-          "position": 405
-        }
-      },
-      "secondFile": {
-        "name": "packages/history/test/recorder.test.ts",
-        "start": 21,
-        "end": 31,
-        "startLoc": {
-          "line": 21,
-          "column": 2,
-          "position": 203
-        },
-        "endLoc": {
-          "line": 31,
-          "column": 2,
-          "position": 292
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 15,
-      "fragment": ",\n        stderr: '',\n        exitCode: 0,\n      })\n      .mockReturnValueOnce({\n        success: true,\n        stdout: '0\\n',\n        stderr: '',\n        exitCode: 0,\n      });\n\n    const result = isCurrentBranchBehindTracking();\n\n    expect(result).toBe(0);\n  }",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/git/test/tracking-branch.test.ts",
-        "start": 98,
-        "end": 112,
-        "startLoc": {
-          "line": 98,
-          "column": 16,
-          "position": 653
-        },
-        "endLoc": {
-          "line": 112,
-          "column": 2,
-          "position": 739
-        }
-      },
-      "secondFile": {
-        "name": "packages/git/test/tracking-branch.test.ts",
-        "start": 46,
-        "end": 60,
-        "startLoc": {
-          "line": 46,
-          "column": 23,
-          "position": 302
-        },
-        "endLoc": {
-          "line": 60,
-          "column": 7,
-          "position": 388
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 16,
-      "fragment": ",\n          metadata: {\n            confidence: 100,\n            completeness: 100,\n            issues: [],\n            detection: {\n              extractor: 'vitest',\n              confidence: 100,\n              patterns: [],\n              reason: 'test',\n            },\n          },\n        },\n      };\n\n      const result = StepResultSchema.parse",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/core/test/step-result-schema.test.ts",
-        "start": 111,
-        "end": 126,
-        "startLoc": {
-          "line": 111,
-          "column": 3,
-          "position": 783
-        },
-        "endLoc": {
-          "line": 126,
-          "column": 6,
-          "position": 874
-        }
-      },
-      "secondFile": {
-        "name": "packages/core/test/step-result-schema.test.ts",
-        "start": 52,
-        "end": 67,
-        "startLoc": {
-          "line": 52,
-          "column": 37,
-          "position": 332
-        },
-        "endLoc": {
-          "line": 67,
-          "column": 10,
-          "position": 423
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 15,
-      "fragment": "];\n\n      // Check that expected fields appear in order\n      let lastIndex = -1;\n      for (const expectedKey of expectedOrder) {\n        const currentIndex = keys.indexOf(expectedKey);\n        if (currentIndex !== -1) {\n          expect(currentIndex).toBeGreaterThan(lastIndex);\n          lastIndex = currentIndex;\n        }\n      }\n    });\n  });\n\n  describe('v0.15.0 breaking changes'",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/core/test/step-result-schema.test.ts",
-        "start": 138,
-        "end": 152,
-        "startLoc": {
-          "line": 138,
-          "column": 7,
-          "position": 948
-        },
-        "endLoc": {
-          "line": 152,
-          "column": 27,
-          "position": 1050
-        }
-      },
-      "secondFile": {
-        "name": "packages/cli/test/schemas/run-result-schema.test.ts",
-        "start": 75,
-        "end": 89,
-        "startLoc": {
-          "line": 75,
-          "column": 7,
-          "position": 499
-        },
-        "endLoc": {
-          "line": 89,
-          "column": 24,
-          "position": 601
-        }
-      }
-    },
-    {
-      "format": "typescript",
-      "lines": 13,
-      "fragment": ", // ❌ Removed in v0.15.0\n      };\n\n      const result = StepResultSchema.safeParse(stepWithOldFormat);\n\n      expect(result.success).toBe(false);\n      if (!result.success) {\n        expect(result.error.errors.some(e =>\n          e.message.includes('Unrecognized key')\n        )).toBe(true);\n      }\n    });\n  }",
-      "tokens": 0,
-      "firstFile": {
-        "name": "packages/core/test/step-result-schema.test.ts",
-        "start": 180,
-        "end": 192,
-        "startLoc": {
-          "line": 180,
-          "column": 2,
-          "position": 1287
-        },
-        "endLoc": {
-          "line": 192,
-          "column": 2,
-          "position": 1382
-        }
-      },
-      "secondFile": {
-        "name": "packages/core/test/step-result-schema.test.ts",
-        "start": 160,
-        "end": 173,
-        "startLoc": {
-          "line": 160,
-          "column": 19,
-          "position": 1125
-        },
-        "endLoc": {
-          "line": 173,
-          "column": 3,
-          "position": 1221
         }
       }
     },

--- a/packages/cli/src/commands/pre-commit.ts
+++ b/packages/cli/src/commands/pre-commit.ts
@@ -9,9 +9,10 @@ import { getRemoteBranch } from '@vibe-validate/config';
 import {
   checkBranchSync,
   getPartiallyStagedFiles,
-  isCurrentBranchBehindTracking,
+  getTrackingDivergence,
   getGitTreeHash,
-  isMergeInProgress
+  isMergeInProgress,
+  isRebaseInProgress
 } from '@vibe-validate/git';
 import { isToolAvailable } from '@vibe-validate/utils';
 import chalk from 'chalk';
@@ -144,13 +145,18 @@ export function preCommitCommand(program: Command): void {
         }
         console.log(chalk.green('✅ No partially staged files'));
 
-        // Step 3: Check if current branch is behind its remote tracking branch
-        console.log(chalk.blue('🔍 Checking if current branch is behind remote...'));
-        const behindTracking = isCurrentBranchBehindTracking();
+        // Step 3: Check how current branch diverges from its remote tracking branch
+        console.log(chalk.blue('🔍 Checking divergence from remote tracking branch...'));
+        const divergence = getTrackingDivergence();
 
-        if (behindTracking !== null && behindTracking > 0) {
+        if (divergence === null) {
+          console.log(chalk.gray('ℹ️  No remote tracking branch (new branch or not pushed yet)'));
+        } else if (divergence.ahead === 0 && divergence.behind === 0) {
+          console.log(chalk.green('✅ Current branch is up to date with remote'));
+        } else if (divergence.ahead === 0 && divergence.behind > 0) {
+          // Purely behind: someone else pushed. Legitimate fail.
           console.error(chalk.red(`❌ Current branch is behind its remote tracking branch`));
-          console.error(chalk.yellow(`   Behind by ${behindTracking} commit(s)`));
+          console.error(chalk.yellow(`   Behind by ${divergence.behind} commit(s)`));
           console.error(chalk.yellow('   Someone else has pushed changes to this branch.'));
 
           showWorkProtectionMessage(treeHash, 'git pull', programName);
@@ -158,24 +164,31 @@ export function preCommitCommand(program: Command): void {
           console.error(chalk.gray('\n   Alternative: git pull --rebase'));
           console.error(chalk.gray('\n   Skip this check with: --skip-sync (not recommended)'));
           process.exit(1);
-        }
-
-        if (behindTracking === null) {
-          console.log(chalk.gray('ℹ️  No remote tracking branch (new branch or not pushed yet)'));
+        } else if (divergence.ahead > 0 && divergence.behind === 0) {
+          // Purely ahead: local unpushed commits. Normal mid-PR state.
+          console.log(chalk.green(`✅ Local branch is ahead of remote by ${divergence.ahead} commit(s) (unpushed)`));
         } else {
-          console.log(chalk.green('✅ Current branch is up to date with remote'));
+          // Diverged: history rewritten (typically a rebase). Pass with notice.
+          console.log(chalk.blue('ℹ️  Local branch has rewritten history vs remote tracking branch.'));
+          console.log(chalk.gray(`   Ahead by ${divergence.ahead} commit(s), behind by ${divergence.behind} commit(s) (rebased history).`));
+          console.log(chalk.gray('   When ready to push: git push --force-with-lease'));
         }
 
-        // Step 4: Check branch sync (unless skipped or in merge)
+        // Step 4: Check branch sync (unless skipped, mid-merge, or mid-rebase)
         if (!options.skipSync) {
           // Construct remote branch reference using helper
           const remoteBranch = getRemoteBranch(config.git);
 
-          // Check if we're in the middle of a merge (MERGE_HEAD exists)
-          // During a merge, being behind origin/main is expected - the merge commit will resolve it
+          // Skip the base-branch sync check while a merge or rebase is mid-flight.
+          // During a merge, being behind origin/main is expected - the merge commit
+          // will resolve it. During a rebase, HEAD is transiently rewinding and
+          // checking sync would produce misleading results.
           if (isMergeInProgress()) {
             console.log(chalk.blue(`🔄 Merge in progress - skipping branch sync check`));
             console.log(chalk.gray(`   (This merge commit will sync with ${remoteBranch})`));
+          } else if (isRebaseInProgress()) {
+            console.log(chalk.blue(`🔄 Rebase in progress - skipping branch sync check`));
+            console.log(chalk.gray(`   (Sync state will settle once the rebase completes)`));
           } else {
             console.log(chalk.blue(`🔄 Checking branch sync with ${remoteBranch}...`));
 

--- a/packages/cli/test/commands/pre-commit.test.ts
+++ b/packages/cli/test/commands/pre-commit.test.ts
@@ -667,6 +667,34 @@ describe('pre-commit command', () => {
     });
   });
 
+  describe('rebase divergence handling (Issue #155)', () => {
+    it('should pass pre-commit when local history is rewritten (ahead AND behind tracking)', async () => {
+      // Classic post-rebase shape: ahead by N (rewritten commits), behind by M
+      // (pre-rebase originals still on origin). Pre-commit must NOT fail here —
+      // the user will force-push-with-lease when ready.
+      setupSuccessfulPreCommit();
+      vi.mocked(git.getTrackingDivergence).mockReturnValue({ ahead: 5, behind: 3 });
+
+      await runPreCommit(env, 0);
+
+      expect(git.getTrackingDivergence).toHaveBeenCalled();
+    });
+
+    it('should skip base-branch sync check when a rebase is in progress', async () => {
+      // During an interactive rebase pause (e.g. edit step), HEAD is transiently
+      // rewinding; sync against origin/main is meaningless. Mirror the merge
+      // short-circuit: skip checkBranchSync, let validation run.
+      vi.mocked(configLoader.loadConfig).mockResolvedValue(createConfig());
+      vi.mocked(git.isRebaseInProgress).mockReturnValue(true);
+      vi.mocked(core.runValidation).mockResolvedValue(createValidationResult());
+
+      await runPreCommit(env, 0);
+
+      expect(git.isRebaseInProgress).toHaveBeenCalled();
+      expect(git.checkBranchSync).not.toHaveBeenCalled();
+    });
+  });
+
   describe('dependency lock check integration', () => {
     it('should run dependency check with runOn: pre-commit during pre-commit', async () => {
       setupDependencyCheckTest('pre-commit');

--- a/packages/cli/test/commands/pre-commit.test.ts
+++ b/packages/cli/test/commands/pre-commit.test.ts
@@ -671,22 +671,26 @@ describe('pre-commit command', () => {
     it('should pass pre-commit when local history is rewritten (ahead AND behind tracking)', async () => {
       // Classic post-rebase shape: ahead by N (rewritten commits), behind by M
       // (pre-rebase originals still on origin). Pre-commit must NOT fail here —
-      // the user will force-push-with-lease when ready.
+      // the user will force-push-with-lease when ready. Step 3 should pass-through
+      // to Step 4 (checkBranchSync) rather than bail with exit 1.
       setupSuccessfulPreCommit();
       vi.mocked(git.getTrackingDivergence).mockReturnValue({ ahead: 5, behind: 3 });
 
       await runPreCommit(env, 0);
 
       expect(git.getTrackingDivergence).toHaveBeenCalled();
+      // checkBranchSync only runs if Step 3 didn't bail — this pins the diverged
+      // pass-through path (the bug fix). Without it, the test would also pass
+      // if the mock returned {0, 0} or {N, 0}.
+      expect(git.checkBranchSync).toHaveBeenCalled();
     });
 
     it('should skip base-branch sync check when a rebase is in progress', async () => {
       // During an interactive rebase pause (e.g. edit step), HEAD is transiently
       // rewinding; sync against origin/main is meaningless. Mirror the merge
       // short-circuit: skip checkBranchSync, let validation run.
-      vi.mocked(configLoader.loadConfig).mockResolvedValue(createConfig());
+      setupSuccessfulPreCommit();
       vi.mocked(git.isRebaseInProgress).mockReturnValue(true);
-      vi.mocked(core.runValidation).mockResolvedValue(createValidationResult());
 
       await runPreCommit(env, 0);
 

--- a/packages/cli/test/commands/pre-commit.test.ts
+++ b/packages/cli/test/commands/pre-commit.test.ts
@@ -41,9 +41,10 @@ vi.mock('@vibe-validate/git', async () => {
     checkBranchSync: vi.fn(),
     getGitTreeHash: vi.fn(),
     getRepositoryRoot: vi.fn(),
-    isCurrentBranchBehindTracking: vi.fn(),
+    getTrackingDivergence: vi.fn(),
     getPartiallyStagedFiles: vi.fn().mockReturnValue([]),
     isMergeInProgress: vi.fn(),
+    isRebaseInProgress: vi.fn(),
   };
 });
 
@@ -246,7 +247,9 @@ function setupBranchBehind(behindBy: number, hasTracking = true) {
     hash: 'abc123def456' as git.TreeHash,
   });
   vi.mocked(git.getPartiallyStagedFiles).mockReturnValue([]);
-  vi.mocked(git.isCurrentBranchBehindTracking).mockReturnValue(hasTracking ? behindBy : null);
+  vi.mocked(git.getTrackingDivergence).mockReturnValue(
+    hasTracking ? { ahead: 0, behind: behindBy } : null
+  );
   vi.mocked(git.checkBranchSync).mockResolvedValue(
     createBranchSyncResult({ isUpToDate: false, behindBy })
   );
@@ -457,9 +460,10 @@ describe('pre-commit command', () => {
     vi.mocked(git.checkBranchSync).mockReset();
     vi.mocked(git.getGitTreeHash).mockReset();
     vi.mocked(git.getRepositoryRoot).mockReset();
-    vi.mocked(git.isCurrentBranchBehindTracking).mockReset();
+    vi.mocked(git.getTrackingDivergence).mockReset();
     vi.mocked(git.getPartiallyStagedFiles).mockReset();
     vi.mocked(git.isMergeInProgress).mockReset();
+    vi.mocked(git.isRebaseInProgress).mockReset();
     vi.mocked(utils.safeExecSync).mockReset();
     vi.mocked(utils.safeExecFromString).mockReset();
     vi.mocked(utils.isToolAvailable).mockReset();
@@ -471,9 +475,10 @@ describe('pre-commit command', () => {
       hash: 'abc123def456' as git.TreeHash,
       });
     vi.mocked(git.getRepositoryRoot).mockReturnValue('/test/repo'); // Default git repo path
-    vi.mocked(git.isCurrentBranchBehindTracking).mockReturnValue(0); // Up to date by default
+    vi.mocked(git.getTrackingDivergence).mockReturnValue({ ahead: 0, behind: 0 }); // Up to date by default
     vi.mocked(git.getPartiallyStagedFiles).mockReturnValue([]); // No partially staged by default
     vi.mocked(git.isMergeInProgress).mockReturnValue(false); // No merge by default
+    vi.mocked(git.isRebaseInProgress).mockReturnValue(false); // No rebase by default
     vi.mocked(utils.safeExecSync).mockReturnValue(''); // Default empty output
     vi.mocked(utils.safeExecFromString).mockReturnValue(''); // Default empty output
     vi.mocked(utils.isToolAvailable).mockReturnValue(false); // No tools available by default

--- a/packages/git/src/git-commands.ts
+++ b/packages/git/src/git-commands.ts
@@ -117,12 +117,19 @@ export function isMergeInProgress(): boolean {
  * and `rebase-apply` (legacy `am`-based). Either being present means a
  * rebase is mid-flight.
  *
+ * Returns `false` (rather than throwing) when called outside a git
+ * repository, matching the contract of `isMergeInProgress()`.
+ *
  * @returns true if a rebase is in progress, false otherwise
  */
 export function isRebaseInProgress(): boolean {
-  const gitDir = getGitDir();
-  return existsSync(join(gitDir, 'rebase-merge'))
-    || existsSync(join(gitDir, 'rebase-apply'));
+  try {
+    const gitDir = getGitDir();
+    return existsSync(join(gitDir, 'rebase-merge'))
+      || existsSync(join(gitDir, 'rebase-apply'));
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/git/src/git-commands.ts
+++ b/packages/git/src/git-commands.ts
@@ -123,13 +123,12 @@ export function isMergeInProgress(): boolean {
  * @returns true if a rebase is in progress, false otherwise
  */
 export function isRebaseInProgress(): boolean {
-  try {
-    const gitDir = getGitDir();
-    return existsSync(join(gitDir, 'rebase-merge'))
-      || existsSync(join(gitDir, 'rebase-apply'));
-  } catch {
+  if (!isGitRepository()) {
     return false;
   }
+  const gitDir = getGitDir();
+  return existsSync(join(gitDir, 'rebase-merge'))
+    || existsSync(join(gitDir, 'rebase-apply'));
 }
 
 /**

--- a/packages/git/src/git-commands.ts
+++ b/packages/git/src/git-commands.ts
@@ -5,6 +5,9 @@
  * These functions provide convenient access to common git commands.
  */
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { execGitCommand, tryGitCommand } from './git-executor.js';
 
 /**
@@ -104,6 +107,22 @@ export function hasNotesRef(notesRef: string): boolean {
  */
 export function isMergeInProgress(): boolean {
   return tryGitCommand(['rev-parse', '--verify', '--quiet', 'MERGE_HEAD']);
+}
+
+/**
+ * Check if git is currently in the middle of a rebase.
+ *
+ * Git uses two different scratch directories depending on which rebase
+ * backend is active: `rebase-merge` (interactive / default since git 2.26)
+ * and `rebase-apply` (legacy `am`-based). Either being present means a
+ * rebase is mid-flight.
+ *
+ * @returns true if a rebase is in progress, false otherwise
+ */
+export function isRebaseInProgress(): boolean {
+  const gitDir = getGitDir();
+  return existsSync(join(gitDir, 'rebase-merge'))
+    || existsSync(join(gitDir, 'rebase-apply'));
 }
 
 /**

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -57,6 +57,7 @@ export {
   verifyRefOrThrow,
   hasNotesRef,
   isMergeInProgress,
+  isRebaseInProgress,
   getDiffStats,
   getCommitCount,
   getNotesRefs
@@ -95,9 +96,11 @@ export {
   getPartiallyStagedFiles
 } from './staging.js';
 
-// Git tracking branch detection (check if current branch is behind remote)
+// Git tracking branch detection (check if current branch diverges from remote)
 export {
-  isCurrentBranchBehindTracking
+  getTrackingDivergence,
+  isCurrentBranchBehindTracking,
+  type TrackingDivergence
 } from './tracking-branch.js';
 
 // GitHub CLI commands (centralized gh command execution)

--- a/packages/git/src/tracking-branch.ts
+++ b/packages/git/src/tracking-branch.ts
@@ -1,18 +1,28 @@
 /**
- * Git Tracking Branch Detection
+ * Git Tracking Branch Divergence Detection
  *
- * Detects if current branch is behind its remote tracking branch.
+ * Compares the current branch against its remote tracking branch and reports
+ * how many commits diverge on each side.
  *
  * ## The Problem
  *
- * If you're working on local `fix-issue-X` and someone else pushes to `origin/fix-issue-X`:
- * 1. Your local branch is now behind the remote tracking branch
- * 2. If you commit and push, you may create conflicts or lose their changes
- * 3. You should pull/merge before committing
+ * Two different real-world conditions can leave the local branch out of sync
+ * with its upstream, and the pre-commit hook needs to treat them differently:
+ *
+ * 1. **Purely behind** — someone else pushed to origin while we worked locally.
+ *    `ahead = 0`, `behind > 0`. The user must pull before committing.
+ * 2. **Diverged** — we rebased our feature branch onto an updated base; the
+ *    upstream branch still has the pre-rebase commits. `ahead > 0`, `behind > 0`.
+ *    The user will force-push-with-lease when ready; pre-commit should NOT block.
+ *
+ * A simple "is the branch behind?" check (e.g. counting `HEAD..@{u}`) cannot
+ * tell these apart, because in both cases the upstream contains commits not
+ * reachable from HEAD. We need both sides of the comparison.
  *
  * ## Solution
  *
- * Pre-commit hook should detect and warn when current branch is behind its tracking branch.
+ * Use `git rev-list --left-right --count HEAD...@{u}`, which returns
+ * `<ahead>\t<behind>` in a single deterministic call.
  */
 
 import { executeGitCommand } from './git-executor.js';
@@ -20,58 +30,94 @@ import { executeGitCommand } from './git-executor.js';
 const GIT_TIMEOUT = 30000;
 
 /**
- * Check if current branch is behind its remote tracking branch
+ * Divergence between HEAD and its remote tracking branch.
  *
- * @returns Number of commits behind (0 = up to date), or null if no tracking branch
+ * - `ahead`: commits on HEAD that are not on upstream
+ * - `behind`: commits on upstream that are not on HEAD
+ */
+export interface TrackingDivergence {
+  ahead: number;
+  behind: number;
+}
+
+/**
+ * Check how the current branch diverges from its remote tracking branch.
+ *
+ * @returns The ahead/behind counts, or `null` if there is no upstream
+ *          tracking branch (e.g. a freshly created local branch).
  *
  * @example
  * ```typescript
- * const behindBy = isCurrentBranchBehindTracking();
- * if (behindBy === null) {
- *   console.log('No remote tracking branch');
- * } else if (behindBy > 0) {
- *   console.error(`Behind by ${behindBy} commit(s)`);
- *   console.error('Pull changes with: git pull');
+ * const div = getTrackingDivergence();
+ * if (div === null) {
+ *   // No upstream — nothing to compare against.
+ * } else if (div.ahead === 0 && div.behind === 0) {
+ *   // Fully synced.
+ * } else if (div.ahead === 0 && div.behind > 0) {
+ *   // Purely behind — someone else pushed; pull before committing.
+ * } else if (div.ahead > 0 && div.behind === 0) {
+ *   // Ahead only — local commits not yet pushed.
+ * } else {
+ *   // Diverged (e.g. rebased) — force-push-with-lease when ready.
  * }
  * ```
  */
-export function isCurrentBranchBehindTracking(): number | null {
+export function getTrackingDivergence(): TrackingDivergence | null {
   try {
-    // Get the upstream tracking branch for current branch
-    // Example output: "origin/fix-issue-X"
-    // Throws error if no upstream configured
-    const trackingResult = executeGitCommand(
+    // Confirm an upstream exists first. Without this, the rev-list call
+    // below would fail with the same "no upstream" error and we'd have to
+    // pattern-match on stderr to distinguish it from real errors.
+    const upstreamResult = executeGitCommand(
       ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
       { timeout: GIT_TIMEOUT, ignoreErrors: true }
     );
 
-    if (!trackingResult.success || !trackingResult.stdout.trim()) {
-      // No tracking branch or command failed
+    if (!upstreamResult.success || !upstreamResult.stdout.trim()) {
       return null;
     }
 
-    // Count commits behind: HEAD..@{u}
-    // This shows commits in tracking branch that are not in HEAD
-    const behindResult = executeGitCommand(
-      ['rev-list', '--count', 'HEAD..@{u}'],
+    // `--left-right --count HEAD...@{u}` returns `<ahead>\t<behind>`.
+    // The triple-dot (...) means "symmetric difference": commits reachable
+    // from exactly one side. --left-right tags each commit with < (left
+    // side = HEAD) or > (right side = @{u}); --count collapses to counts.
+    const divergenceResult = executeGitCommand(
+      ['rev-list', '--left-right', '--count', 'HEAD...@{u}'],
       { timeout: GIT_TIMEOUT, ignoreErrors: true }
     );
 
-    if (!behindResult.success) {
+    if (!divergenceResult.success) {
       return null;
     }
 
-    const behindCount = Number.parseInt(behindResult.stdout.trim(), 10);
+    const [aheadRaw, behindRaw] = divergenceResult.stdout.trim().split(/\s+/);
+    const ahead = Number.parseInt(aheadRaw ?? '', 10);
+    const behind = Number.parseInt(behindRaw ?? '', 10);
 
-    // Return 0 if parsing failed (defensive)
-    return Number.isNaN(behindCount) ? 0 : behindCount;
+    return {
+      ahead: Number.isNaN(ahead) ? 0 : ahead,
+      behind: Number.isNaN(behind) ? 0 : behind,
+    };
   } catch (error) {
-    // Check if error is "no upstream configured" (expected for new branches)
     if (error instanceof Error && error.message.includes('no upstream')) {
       return null;
     }
-
-    // Other errors (not in git repo, etc.) - return null
     return null;
   }
+}
+
+/**
+ * Check if the current branch is behind its remote tracking branch.
+ *
+ * @deprecated Prefer {@link getTrackingDivergence}, which distinguishes
+ * "purely behind" (someone pushed) from "diverged" (we rebased). This
+ * wrapper only reports the behind count and treats diverged branches the
+ * same as purely-behind ones — which incorrectly blocks legitimate
+ * post-rebase commits in pre-commit hooks. Retained for backwards
+ * compatibility with external consumers of `@vibe-validate/git`.
+ *
+ * @returns Number of commits behind, or `null` if no tracking branch.
+ */
+export function isCurrentBranchBehindTracking(): number | null {
+  const divergence = getTrackingDivergence();
+  return divergence === null ? null : divergence.behind;
 }

--- a/packages/git/test/git-commands.test.ts
+++ b/packages/git/test/git-commands.test.ts
@@ -4,6 +4,9 @@
  * Tests the high-level git command wrappers that build on git-executor.
  */
 
+import { existsSync } from 'node:fs';
+import type * as nodeFs from 'node:fs';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
@@ -18,6 +21,7 @@ import {
   verifyRefOrThrow,
   hasNotesRef,
   isMergeInProgress,
+  isRebaseInProgress,
   getDiffStats,
   getCommitCount,
   getNotesRefs,
@@ -31,6 +35,15 @@ vi.mock('../src/git-executor.js', async () => {
     ...actual,
     execGitCommand: vi.fn(),
     tryGitCommand: vi.fn(),
+  };
+});
+
+// Mock node:fs for filesystem-based checks (e.g. .git/rebase-merge directory)
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof nodeFs>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
   };
 });
 
@@ -240,6 +253,50 @@ describe('git-commands', () => {
       const result = isMergeInProgress();
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('isRebaseInProgress', () => {
+    const GIT_DIR = '/path/to/repo/.git';
+
+    beforeEach(() => {
+      vi.mocked(gitExecutor.execGitCommand).mockReturnValue(GIT_DIR);
+    });
+
+    it('should return true when .git/rebase-merge directory exists (interactive rebase)', () => {
+      vi.mocked(existsSync).mockImplementation((p) =>
+        p === `${GIT_DIR}/rebase-merge`
+      );
+
+      expect(isRebaseInProgress()).toBe(true);
+    });
+
+    it('should return true when .git/rebase-apply directory exists (am-based rebase)', () => {
+      vi.mocked(existsSync).mockImplementation((p) =>
+        p === `${GIT_DIR}/rebase-apply`
+      );
+
+      expect(isRebaseInProgress()).toBe(true);
+    });
+
+    it('should return true when both rebase directories exist', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      expect(isRebaseInProgress()).toBe(true);
+    });
+
+    it('should return false when no rebase is in progress', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      expect(isRebaseInProgress()).toBe(false);
+    });
+
+    it('should not be confused by a similarly-named file (only checks rebase-merge/rebase-apply)', () => {
+      vi.mocked(existsSync).mockImplementation((p) =>
+        p === `${GIT_DIR}/MERGE_HEAD` || p === `${GIT_DIR}/rebase-stash`
+      );
+
+      expect(isRebaseInProgress()).toBe(false);
     });
   });
 

--- a/packages/git/test/git-commands.test.ts
+++ b/packages/git/test/git-commands.test.ts
@@ -267,6 +267,8 @@ describe('git-commands', () => {
     const REBASE_STASH_PATH = join(GIT_DIR, 'rebase-stash');
 
     beforeEach(() => {
+      // Inside a git repo by default; the "no repo" test overrides this.
+      vi.mocked(gitExecutor.tryGitCommand).mockReturnValue(true);
       vi.mocked(gitExecutor.execGitCommand).mockReturnValue(GIT_DIR);
     });
 
@@ -303,11 +305,9 @@ describe('git-commands', () => {
     });
 
     it('should return false (not throw) when outside a git repository', () => {
-      // getGitDir() throws when not in a repo; isRebaseInProgress should
-      // match isMergeInProgress's contract and return false silently.
-      vi.mocked(gitExecutor.execGitCommand).mockImplementation(() => {
-        throw new Error('fatal: not a git repository');
-      });
+      // Outside a repo, isRebaseInProgress short-circuits via isGitRepository
+      // before ever calling getGitDir, matching isMergeInProgress's contract.
+      vi.mocked(gitExecutor.tryGitCommand).mockReturnValue(false);
 
       expect(() => isRebaseInProgress()).not.toThrow();
       expect(isRebaseInProgress()).toBe(false);

--- a/packages/git/test/git-commands.test.ts
+++ b/packages/git/test/git-commands.test.ts
@@ -6,6 +6,7 @@
 
 import { existsSync } from 'node:fs';
 import type * as nodeFs from 'node:fs';
+import { join } from 'node:path';
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -258,23 +259,25 @@ describe('git-commands', () => {
 
   describe('isRebaseInProgress', () => {
     const GIT_DIR = '/path/to/repo/.git';
+    // Production uses path.join, which produces backslash separators on Windows.
+    // Build comparison paths the same way so the mock matches on every platform.
+    const REBASE_MERGE_PATH = join(GIT_DIR, 'rebase-merge');
+    const REBASE_APPLY_PATH = join(GIT_DIR, 'rebase-apply');
+    const MERGE_HEAD_PATH = join(GIT_DIR, 'MERGE_HEAD');
+    const REBASE_STASH_PATH = join(GIT_DIR, 'rebase-stash');
 
     beforeEach(() => {
       vi.mocked(gitExecutor.execGitCommand).mockReturnValue(GIT_DIR);
     });
 
     it('should return true when .git/rebase-merge directory exists (interactive rebase)', () => {
-      vi.mocked(existsSync).mockImplementation((p) =>
-        p === `${GIT_DIR}/rebase-merge`
-      );
+      vi.mocked(existsSync).mockImplementation((p) => p === REBASE_MERGE_PATH);
 
       expect(isRebaseInProgress()).toBe(true);
     });
 
     it('should return true when .git/rebase-apply directory exists (am-based rebase)', () => {
-      vi.mocked(existsSync).mockImplementation((p) =>
-        p === `${GIT_DIR}/rebase-apply`
-      );
+      vi.mocked(existsSync).mockImplementation((p) => p === REBASE_APPLY_PATH);
 
       expect(isRebaseInProgress()).toBe(true);
     });
@@ -293,9 +296,20 @@ describe('git-commands', () => {
 
     it('should not be confused by a similarly-named file (only checks rebase-merge/rebase-apply)', () => {
       vi.mocked(existsSync).mockImplementation((p) =>
-        p === `${GIT_DIR}/MERGE_HEAD` || p === `${GIT_DIR}/rebase-stash`
+        p === MERGE_HEAD_PATH || p === REBASE_STASH_PATH
       );
 
+      expect(isRebaseInProgress()).toBe(false);
+    });
+
+    it('should return false (not throw) when outside a git repository', () => {
+      // getGitDir() throws when not in a repo; isRebaseInProgress should
+      // match isMergeInProgress's contract and return false silently.
+      vi.mocked(gitExecutor.execGitCommand).mockImplementation(() => {
+        throw new Error('fatal: not a git repository');
+      });
+
+      expect(() => isRebaseInProgress()).not.toThrow();
       expect(isRebaseInProgress()).toBe(false);
     });
   });

--- a/packages/git/test/tracking-branch.test.ts
+++ b/packages/git/test/tracking-branch.test.ts
@@ -1,27 +1,51 @@
 /**
- * Tests for checking if current branch is behind its remote tracking branch
+ * Tests for checking divergence between current branch and its remote tracking branch
  *
- * CRITICAL: If someone else pushes to origin/fix-issue-X while you're working
- * on local fix-issue-X, you need to pull before committing to avoid conflicts.
+ * CRITICAL: After a rebase, the local branch is BOTH ahead of and behind its tracking
+ * branch (the rewritten commits vs the pre-rebase originals). The legacy
+ * isCurrentBranchBehindTracking check could not distinguish "purely behind"
+ * (someone else pushed) from "diverged" (we rebased), causing pre-commit to
+ * incorrectly block legitimate post-rebase commits.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import * as gitExecutor from '../src/git-executor.js';
-import { isCurrentBranchBehindTracking } from '../src/tracking-branch.js';
+import {
+  getTrackingDivergence,
+  // eslint-disable-next-line sonarjs/deprecation -- tests intentionally exercise the deprecated wrapper to verify backwards-compat
+  isCurrentBranchBehindTracking,
+} from '../src/tracking-branch.js';
 
 // Mock git-executor
 vi.mock('../src/git-executor.js', () => ({
   executeGitCommand: vi.fn(),
 }));
 
-describe('isCurrentBranchBehindTracking', () => {
+const UPSTREAM_OK = {
+  success: true,
+  stdout: 'origin/fix-issue-X\n',
+  stderr: '',
+  exitCode: 0,
+};
+
+function mockDivergence(aheadBehind: string): void {
+  vi.mocked(gitExecutor.executeGitCommand)
+    .mockReturnValueOnce(UPSTREAM_OK)
+    .mockReturnValueOnce({
+      success: true,
+      stdout: `${aheadBehind}\n`,
+      stderr: '',
+      exitCode: 0,
+    });
+}
+
+describe('getTrackingDivergence', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should return null when branch has no upstream tracking branch', () => {
-    // Mock: git rev-parse --abbrev-ref --symbolic-full-name @{u}
     vi.mocked(gitExecutor.executeGitCommand).mockReturnValueOnce({
       success: false,
       stdout: '',
@@ -29,7 +53,7 @@ describe('isCurrentBranchBehindTracking', () => {
       exitCode: 128,
     });
 
-    const result = isCurrentBranchBehindTracking();
+    const result = getTrackingDivergence();
 
     expect(result).toBeNull();
     expect(gitExecutor.executeGitCommand).toHaveBeenCalledWith(
@@ -38,95 +62,47 @@ describe('isCurrentBranchBehindTracking', () => {
     );
   });
 
-  it('should return 0 when branch is up to date with tracking branch', () => {
-    // Mock: git rev-parse --abbrev-ref --symbolic-full-name @{u}
-    vi.mocked(gitExecutor.executeGitCommand)
-      .mockReturnValueOnce({
-        success: true,
-        stdout: 'origin/fix-issue-X\n',
-        stderr: '',
-        exitCode: 0,
-      })
-      .mockReturnValueOnce({
-        success: true,
-        stdout: '0\n',
-        stderr: '',
-        exitCode: 0,
-      });
+  it('should return {ahead: 0, behind: 0} when branch is up to date', () => {
+    mockDivergence('0\t0');
 
-    const result = isCurrentBranchBehindTracking();
+    const result = getTrackingDivergence();
 
-    expect(result).toBe(0);
-    expect(gitExecutor.executeGitCommand).toHaveBeenNthCalledWith(
-      1,
-      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
-      expect.any(Object)
-    );
+    expect(result).toEqual({ ahead: 0, behind: 0 });
     expect(gitExecutor.executeGitCommand).toHaveBeenNthCalledWith(
       2,
-      ['rev-list', '--count', 'HEAD..@{u}'],
+      ['rev-list', '--left-right', '--count', 'HEAD...@{u}'],
       expect.any(Object)
     );
   });
 
-  it('should return commit count when branch is behind tracking branch', () => {
-    // Mock: git rev-parse --abbrev-ref --symbolic-full-name @{u}
-    vi.mocked(gitExecutor.executeGitCommand)
-      .mockReturnValueOnce({
-        success: true,
-        stdout: 'origin/fix-issue-X\n',
-        stderr: '',
-        exitCode: 0,
-      })
-      .mockReturnValueOnce({
-        success: true,
-        stdout: '3\n',
-        stderr: '',
-        exitCode: 0,
-      });
+  it('should return {ahead: 0, behind: N} when purely behind (someone else pushed)', () => {
+    mockDivergence('0\t3');
 
-    const result = isCurrentBranchBehindTracking();
+    const result = getTrackingDivergence();
 
-    expect(result).toBe(3);
+    expect(result).toEqual({ ahead: 0, behind: 3 });
   });
 
-  it('should handle main branch with tracking', () => {
-    // Mock: git rev-parse --abbrev-ref --symbolic-full-name @{u}
-    vi.mocked(gitExecutor.executeGitCommand)
-      .mockReturnValueOnce({
-        success: true,
-        stdout: 'origin/main\n',
-        stderr: '',
-        exitCode: 0,
-      })
-      .mockReturnValueOnce({
-        success: true,
-        stdout: '0\n',
-        stderr: '',
-        exitCode: 0,
-      });
+  it('should return {ahead: N, behind: 0} when purely ahead (local unpushed commits)', () => {
+    mockDivergence('2\t0');
 
-    const result = isCurrentBranchBehindTracking();
+    const result = getTrackingDivergence();
 
-    expect(result).toBe(0);
+    expect(result).toEqual({ ahead: 2, behind: 0 });
   });
 
-  it('should return null on git command error (not "no upstream" error)', () => {
-    // Mock: git rev-parse throws unexpected error
-    vi.mocked(gitExecutor.executeGitCommand).mockReturnValueOnce({
-      success: false,
-      stdout: '',
-      stderr: 'Not a git repository',
-      exitCode: 128,
-    });
+  it('should return {ahead: N, behind: M} when diverged (rebased history)', () => {
+    // Classic post-rebase shape: rebased 3 commits onto a base that advanced
+    // by 2; locally we now have 5 new commits, while origin still has the
+    // 3 pre-rebase originals.
+    mockDivergence('5\t3');
 
-    const result = isCurrentBranchBehindTracking();
+    const result = getTrackingDivergence();
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ahead: 5, behind: 3 });
   });
 
   it('should handle whitespace in git output', () => {
-    // Mock: git rev-parse with extra whitespace
     vi.mocked(gitExecutor.executeGitCommand)
       .mockReturnValueOnce({
         success: true,
@@ -136,34 +112,96 @@ describe('isCurrentBranchBehindTracking', () => {
       })
       .mockReturnValueOnce({
         success: true,
-        stdout: '  2  \n',
+        stdout: '  4\t7  \n',
         stderr: '',
         exitCode: 0,
       });
 
-    const result = isCurrentBranchBehindTracking();
+    const result = getTrackingDivergence();
 
-    expect(result).toBe(2);
+    expect(result).toEqual({ ahead: 4, behind: 7 });
   });
 
-  it('should return 0 for invalid commit count (defensive)', () => {
-    // Mock: git rev-parse
+  it('should return null on unexpected git command failure', () => {
+    vi.mocked(gitExecutor.executeGitCommand).mockReturnValueOnce({
+      success: false,
+      stdout: '',
+      stderr: 'Not a git repository',
+      exitCode: 128,
+    });
+
+    const result = getTrackingDivergence();
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when divergence command fails after upstream lookup succeeds', () => {
     vi.mocked(gitExecutor.executeGitCommand)
+      .mockReturnValueOnce(UPSTREAM_OK)
       .mockReturnValueOnce({
-        success: true,
-        stdout: 'origin/fix-issue-X\n',
-        stderr: '',
-        exitCode: 0,
-      })
-      .mockReturnValueOnce({
-        success: true,
-        stdout: 'invalid\n',
-        stderr: '',
-        exitCode: 0,
+        success: false,
+        stdout: '',
+        stderr: 'fatal: bad revision',
+        exitCode: 128,
       });
 
-    const result = isCurrentBranchBehindTracking();
+    const result = getTrackingDivergence();
 
-    expect(result).toBe(0);
+    expect(result).toBeNull();
+  });
+
+  it('should return {ahead: 0, behind: 0} when count output is malformed (defensive)', () => {
+    mockDivergence('garbage');
+
+    const result = getTrackingDivergence();
+
+    expect(result).toEqual({ ahead: 0, behind: 0 });
   });
 });
+
+// Tests below intentionally call the deprecated wrapper to verify back-compat semantics.
+/* eslint-disable sonarjs/deprecation */
+describe('isCurrentBranchBehindTracking (backwards-compat wrapper)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return null when there is no upstream', () => {
+    vi.mocked(gitExecutor.executeGitCommand).mockReturnValueOnce({
+      success: false,
+      stdout: '',
+      stderr: 'fatal: no upstream configured for branch',
+      exitCode: 128,
+    });
+
+    expect(isCurrentBranchBehindTracking()).toBeNull();
+  });
+
+  it('should return 0 when up to date', () => {
+    mockDivergence('0\t0');
+
+    expect(isCurrentBranchBehindTracking()).toBe(0);
+  });
+
+  it('should return the behind count when purely behind', () => {
+    mockDivergence('0\t3');
+
+    expect(isCurrentBranchBehindTracking()).toBe(3);
+  });
+
+  it('should return the behind count even when also ahead (diverged)', () => {
+    // Wrapper preserves legacy semantics: only reports behind count.
+    // Callers that need to distinguish diverged from purely-behind should
+    // migrate to getTrackingDivergence().
+    mockDivergence('5\t3');
+
+    expect(isCurrentBranchBehindTracking()).toBe(3);
+  });
+
+  it('should return 0 when ahead only', () => {
+    mockDivergence('2\t0');
+
+    expect(isCurrentBranchBehindTracking()).toBe(0);
+  });
+});
+/* eslint-enable sonarjs/deprecation */


### PR DESCRIPTION
## Summary

Fixes #155.

- `isCurrentBranchBehindTracking` was divergence-blind — it counted only commits on upstream not reachable from HEAD (`HEAD..@{u}`), so it couldn't tell "someone else pushed" apart from "we rebased." Pre-commit therefore blocked every post-rebase commit, with no bypass other than `--no-verify`.
- Replaced with `getTrackingDivergence()` returning `{ ahead, behind }` from a single `git rev-list --left-right --count HEAD...@{u}`. Pre-commit's Step 3 now only fails on **purely behind** (`ahead === 0 && behind > 0`); the **diverged** case (`ahead > 0 && behind > 0`, i.e. rebased history) passes with an informational notice pointing at `git push --force-with-lease`.
- Added `isRebaseInProgress()` mirroring `isMergeInProgress()`, used to short-circuit Step 4's base-branch sync check while a rebase is mid-flight (defense-in-depth for interactive-rebase edit steps).
- `isCurrentBranchBehindTracking()` is kept as a deprecated thin wrapper so external consumers of `@vibe-validate/git` aren't broken.

## Test plan

- [x] `pnpm --filter @vibe-validate/git test` — 372/372 pass, including 14 new `getTrackingDivergence` cases (null / `{0,0}` / `{0,N}` / `{N,0}` / `{N,M}` / whitespace / malformed / command-failure) and 5 new `isRebaseInProgress` cases (`rebase-merge`, `rebase-apply`, both, neither, decoy files)
- [x] `pnpm --filter @vibe-validate/cli test pre-commit` — 24/24 pass; pre-commit test mocks updated to new API (`getTrackingDivergence`, `isRebaseInProgress`)
- [x] `pnpm validate` — full suite passes locally on Node 24 (build, typecheck, lint, repo-structure, dup-check, unit+coverage, integration)
- [x] Pre-commit hook self-test: when committing this PR, the new "Checking divergence from remote tracking branch..." path ran and reported the expected `No remote tracking branch (new branch or not pushed yet)` for a freshly created local branch
- [ ] CI on `main`-targeted PR passes on Node 22 (the version CI actually runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)