### PR TITLE
fix(bin): resolve @vibe-validate/cli via createRequire for pnpm strict isolation (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.6] - 2026-05-12
+
+### Fixed
+
+- **`vv pre-commit` no longer blocks legitimate post-rebase commits.** After `git pull --rebase` or a rebase against an updated base, your local branch is "diverged" from its tracking branch — both ahead and behind. The old check treated that state as "behind" and blocked the commit with an unhelpful error. `pre-commit` now distinguishes "purely behind" (legitimate stop — you're missing remote commits) from "diverged" (post-rebase shape — pass with an informational notice), and short-circuits the sync check entirely during a mid-flight rebase, mirroring the existing mid-merge handling. ([#160](https://github.com/jdutton/vibe-validate/pull/160))
+
+- **`vibe-validate` works under pnpm strict isolation.** The umbrella package's bin wrappers (`vibe-validate`, `vv`) used a hardcoded relative path to locate `@vibe-validate/cli`, which only resolves under flat-hoisted `node_modules` (npm classic, bun, yarn classic). Under pnpm's default strict isolation (`node-linker=isolated`), `@vibe-validate/cli` is a *sibling* of `vibe-validate` inside `.pnpm/<id>/node_modules/` rather than nested, so every CLI command crashed with `ERR_MODULE_NOT_FOUND`. The wrappers now resolve the CLI via Node's module algorithm (`createRequire`), which works under every layout: npm flat, pnpm isolated, yarn berry PnP, and bun. ([#161](https://github.com/jdutton/vibe-validate/issues/161))
+
 ## [0.19.5] - 2026-05-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "type": "module",
   "private": true,
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/cli",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Command-line interface for vibe-validate validation framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/test/bin/wrapper.test.ts
+++ b/packages/cli/test/bin/wrapper.test.ts
@@ -15,7 +15,7 @@ import { executeWrapperSync, type WrapperResultSync } from '../helpers/test-comm
  */
 
 // Test constants
-const EXPECTED_VERSION = '0.19.5'; // BUMP_VERSION_UPDATE
+const EXPECTED_VERSION = '0.19.6'; // BUMP_VERSION_UPDATE
 const REPO_ROOT = join(__dirname, '../../../..');
 const PACKAGES_CORE = join(__dirname, '../../../core');
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/config",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Configuration system for vibe-validate with TypeScript-first design and config templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/core",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Core validation orchestration engine for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extractors/package.json
+++ b/packages/extractors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/extractors",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "LLM-optimized error extractors for validation output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/git",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Git utilities for vibe-validate - tree hash calculation, branch sync, and post-merge cleanup",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/history",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Validation history tracking via git notes for vibe-validate",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-validate/utils",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Common utilities for vibe-validate packages (command execution, path normalization)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vibe-validate/bin/vibe-validate
+++ b/packages/vibe-validate/bin/vibe-validate
@@ -7,11 +7,20 @@
  *   VV_ROOT_DIR=~/Workspaces/vibe-validate vibe-validate validate
  */
 import { existsSync } from 'fs';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'url';
 import { dirname, join } from 'path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const require = createRequire(import.meta.url);
+
+// Resolve the published @vibe-validate/cli wrapper via Node's module algorithm
+// so this works under every install layout: npm flat, pnpm strict isolation,
+// yarn berry PnP, bun. (Issue #161 — hardcoded relative paths only work under
+// flat-hoisted node_modules.)
+function resolvePublishedCliWrapper() {
+  const cliPkgJson = require.resolve('@vibe-validate/cli/package.json');
+  return join(dirname(cliPkgJson), 'dist/bin/vibe-validate.js');
+}
 
 // VV_ROOT_DIR override: use dev build's CLI wrapper instead of published one
 // This lets developers test their local build against any project
@@ -24,10 +33,10 @@ if (vvRootDir) {
     cliWrapperPath = devWrapper;
   } else {
     console.error(`[vv] VV_ROOT_DIR set but ${devWrapper} not found — ignoring`);
-    cliWrapperPath = join(__dirname, '../node_modules/@vibe-validate/cli/dist/bin/vibe-validate.js');
+    cliWrapperPath = resolvePublishedCliWrapper();
   }
 } else {
-  cliWrapperPath = join(__dirname, '../node_modules/@vibe-validate/cli/dist/bin/vibe-validate.js');
+  cliWrapperPath = resolvePublishedCliWrapper();
 }
 
 // Import and execute the CLI wrapper

--- a/packages/vibe-validate/bin/vv
+++ b/packages/vibe-validate/bin/vv
@@ -7,11 +7,20 @@
  *   VV_ROOT_DIR=~/Workspaces/vibe-validate vv validate
  */
 import { existsSync } from 'fs';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'url';
 import { dirname, join } from 'path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const require = createRequire(import.meta.url);
+
+// Resolve the published @vibe-validate/cli wrapper via Node's module algorithm
+// so this works under every install layout: npm flat, pnpm strict isolation,
+// yarn berry PnP, bun. (Issue #161 — hardcoded relative paths only work under
+// flat-hoisted node_modules.)
+function resolvePublishedCliWrapper() {
+  const cliPkgJson = require.resolve('@vibe-validate/cli/package.json');
+  return join(dirname(cliPkgJson), 'dist/bin/vibe-validate.js');
+}
 
 // VV_ROOT_DIR override: use dev build's CLI wrapper instead of published one
 // This lets developers test their local build against any project
@@ -24,10 +33,10 @@ if (vvRootDir) {
     cliWrapperPath = devWrapper;
   } else {
     console.error(`[vv] VV_ROOT_DIR set but ${devWrapper} not found — ignoring`);
-    cliWrapperPath = join(__dirname, '../node_modules/@vibe-validate/cli/dist/bin/vibe-validate.js');
+    cliWrapperPath = resolvePublishedCliWrapper();
   }
 } else {
-  cliWrapperPath = join(__dirname, '../node_modules/@vibe-validate/cli/dist/bin/vibe-validate.js');
+  cliWrapperPath = resolvePublishedCliWrapper();
 }
 
 // Import and execute the CLI wrapper

--- a/packages/vibe-validate/package.json
+++ b/packages/vibe-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-validate",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Git-aware validation orchestration for vibe coding (LLM-assisted development) - umbrella package",
   "type": "module",
   "bin": {

--- a/packages/vibe-validate/test/delegation.test.ts
+++ b/packages/vibe-validate/test/delegation.test.ts
@@ -6,11 +6,17 @@
  */
  
 
+import { copyFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { safeExecResult, safeExecSync } from '@vibe-validate/utils';
-import { describe, it, expect } from 'vitest';
+import {
+  mkdirSyncReal,
+  normalizedTmpdir,
+  safeExecResult,
+  safeExecSync,
+} from '@vibe-validate/utils';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -89,5 +95,86 @@ describe('vibe-validate meta-package delegation', () => {
     // Should show doctor command help
     expect(result).toContain('doctor');
     expect(result).toContain('Diagnose');
+  });
+});
+
+/**
+ * Regression: bin wrappers must resolve @vibe-validate/cli via Node's module
+ * algorithm, not via a hardcoded relative `../node_modules/...` path.
+ *
+ * Under pnpm strict isolation (the default), pnpm publishes the package into
+ *   node_modules/.pnpm/vibe-validate@x.y.z/node_modules/vibe-validate/
+ * and places @vibe-validate/cli as a SIBLING (not nested), so the old
+ * `__dirname/../node_modules/@vibe-validate/cli/...` path doesn't exist.
+ *
+ * See: https://github.com/jdutton/vibe-validate/issues/161
+ */
+function runStagedWrapper(stage: string, wrapper: 'vv' | 'vibe-validate'): string {
+  // Strip VV_ROOT_DIR so the wrapper uses the published-path branch, which is
+  // what pnpm consumers actually hit. (Local dev usually sets VV_ROOT_DIR.)
+  const env = { ...process.env };
+  delete env.VV_ROOT_DIR;
+  // eslint-disable-next-line local/no-direct-cli-bin-execution -- Meta-package regression test for issue #161
+  const result = safeExecResult(
+    'node',
+    [join(stage, 'node_modules', 'vibe-validate', 'bin', wrapper)],
+    { encoding: 'utf-8', cwd: stage, env },
+  );
+  return String(result.stdout) + String(result.stderr);
+}
+
+describe('bin wrappers under pnpm-style isolated layout (issue #161)', () => {
+  let stage: string;
+
+  beforeEach(() => {
+    // eslint-disable-next-line sonarjs/pseudo-random -- Safe for test directory uniqueness
+    const uniqueName = `vv-wrapper-iso-${Date.now()}-${Math.random()}`;
+    stage = mkdirSyncReal(join(normalizedTmpdir(), uniqueName), { recursive: true });
+
+    // Layout where @vibe-validate/cli is a sibling, NOT nested:
+    //   <stage>/node_modules/vibe-validate/bin/{vv,vibe-validate}
+    //   <stage>/node_modules/@vibe-validate/cli/{package.json,dist/bin/vibe-validate.js}
+    const pkgDir = join(stage, 'node_modules', 'vibe-validate');
+    const pkgBin = join(pkgDir, 'bin');
+    const cliDir = join(stage, 'node_modules', '@vibe-validate', 'cli');
+    const cliBinDir = join(cliDir, 'dist', 'bin');
+
+    mkdirSyncReal(pkgBin, { recursive: true });
+    mkdirSyncReal(cliBinDir, { recursive: true });
+
+    copyFileSync(join(binDir, 'vv'), join(pkgBin, 'vv'));
+    copyFileSync(join(binDir, 'vibe-validate'), join(pkgBin, 'vibe-validate'));
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'vibe-validate', type: 'module' }),
+    );
+
+    writeFileSync(
+      join(cliDir, 'package.json'),
+      JSON.stringify({
+        name: '@vibe-validate/cli',
+        type: 'module',
+        exports: {
+          '.': './dist/index.js',
+          './package.json': './package.json',
+        },
+      }),
+    );
+    writeFileSync(
+      join(cliBinDir, 'vibe-validate.js'),
+      `console.log('FAKE_CLI_RESOLVED');\n`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(stage, { recursive: true, force: true });
+  });
+
+  it('vv resolves cli through Node module algorithm (not hardcoded relative path)', () => {
+    expect(runStagedWrapper(stage, 'vv')).toContain('FAKE_CLI_RESOLVED');
+  });
+
+  it('vibe-validate resolves cli through Node module algorithm (not hardcoded relative path)', () => {
+    expect(runStagedWrapper(stage, 'vibe-validate')).toContain('FAKE_CLI_RESOLVED');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #161 — the umbrella package's bin wrappers crashed with `ERR_MODULE_NOT_FOUND` under pnpm's default strict isolation, breaking every CLI command for pnpm consumers.

- **Root cause:** `bin/vibe-validate` and `bin/vv` constructed the CLI path with literal filesystem arithmetic (`__dirname/../node_modules/@vibe-validate/cli/...`). That nested layout only exists under flat-hoisted installers. Under pnpm strict isolation, `@vibe-validate/cli` is a *sibling* of `vibe-validate` inside `.pnpm/<id>/node_modules/`, never nested.
- **Fix:** switch both wrappers to `createRequire(import.meta.url).resolve('@vibe-validate/cli/package.json')` + `dirname/join`. This delegates to Node's module algorithm and works under every layout: npm flat, pnpm isolated, yarn berry PnP, bun. Mirrors the `vat` wrapper pattern referenced in the issue.
- **Side fix:** expose `./package.json` in `@vibe-validate/cli`'s `exports` map. Node blocks subpath access (including `./package.json`) when `exports` is set, so the resolver needs this entry.
- `VV_ROOT_DIR` dev-override behavior is unchanged.

## Verification

**Unit test (committed):** stages a pnpm-shaped layout in a temp dir — `@vibe-validate/cli` as a sibling of `vibe-validate`, not nested — and asserts both wrappers resolve a fake CLI. The old hardcoded path cannot resolve in this layout by construction.

**Real pnpm repro (manual):** packed all 8 workspace packages with `pnpm pack`, installed into a fresh consumer with `node-linker=isolated` (the broken default) and `pnpm.overrides` pointing every `@vibe-validate/*` to the local tarballs. Under pnpm 10.33.2 + Node 24.15:

```
$ pnpm exec vibe-validate --version
0.19.6
$ pnpm exec vv --version
0.19.6
$ pnpm exec vv --help
Usage: vibe-validate [options] [command]
...
```

Layout in the consumer matched the issue's stack trace exactly: `node_modules/.pnpm/vibe-validate@.../node_modules/` contained `vibe-validate/` and `@vibe-validate/cli` as siblings, with no nested `vibe-validate/node_modules/@vibe-validate/cli`.

## Release preparation (additional commits on this PR)

This PR also bumps the version to `0.19.6` and documents two `[Unreleased]` entries so the next release is ready to tag:

- **#160** (rebase-aware tracking divergence) — entry was missing when #160 was merged after the v0.19.5 cut. Added here so it ships in 0.19.6 with proper user-facing notes.
- **#161** (this PR, pnpm bin wrapper fix).

`pnpm pre-release --allow-branch fix/issue-161-pnpm-bin-wrapper-resolution` passes:

```
✅ All validation checks passed
✅ v0.19.6 tag does not exist on remote
✅ CHANGELOG section for v0.19.6 has content
✅ Release v0.19.6 is ready! Safe to tag and push.
```

Once this PR merges, maintainer (@jdutton) can `git tag v0.19.6 && git push origin main v0.19.6` to trigger CI publish.

## Test plan

- [x] `pnpm validate` passes (lint, typecheck, build, unit, integration)
- [x] Existing delegation tests still pass (5/5)
- [x] New pnpm-isolated-layout regression tests pass (2/2)
- [x] Real pnpm install repro: `pnpm exec vibe-validate --version` succeeds
- [x] `pnpm pre-release` passes (release readiness)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)