### PR TITLE
feat(cleanup): restore --dry-run flag for branch cleanup

### DIFF
--- a/docs/skills/vibe-validate/cli-reference.md
+++ b/docs/skills/vibe-validate/cli-reference.md
@@ -256,6 +256,10 @@ Comprehensive branch cleanup with GitHub integration
 
 **When to use:** After PR merge to clean up local branches
 
+**Options:**
+
+- `--dry-run` - Preview which branches would be deleted without modifying anything
+
 **Examples:**
 
 ```bash

--- a/packages/cli/src/commands/cleanup.ts
+++ b/packages/cli/src/commands/cleanup.ts
@@ -17,14 +17,15 @@ import { outputYamlResult } from '../utils/yaml-output.js';
 
 
 export function cleanupCommand(program: Command): void {
-  // Branch cleanup - YAML-only output (no options)
+  // Branch cleanup - YAML-only output
   program
     .command('cleanup')
     .description('Comprehensive branch cleanup with GitHub integration')
-    .action(async () => {
+    .option('--dry-run', 'Preview which branches would be deleted without modifying anything')
+    .action(async (options: { dryRun?: boolean }) => {
       try {
         // Run comprehensive branch cleanup
-        const result = await cleanupBranches();
+        const result = await cleanupBranches({ dryRun: options.dryRun });
 
         // Always output YAML (LLM-optimized)
         await outputYamlResult(result);
@@ -175,7 +176,7 @@ The \`cleanup\` command provides LLM-optimized branch cleanup with comprehensive
 - **Smart Categorization**: Auto-deletes 100% safe branches, shows complete context for others
 - **Current Branch Handling**: Automatically switches away if current branch needs cleanup
 - **YAML-Only Output**: LLM-optimized structured data (no human-readable mode)
-- **No Options**: Simple, opinionated design - just run \`cleanup\`
+- **Dry-Run Support**: Use \`--dry-run\` to preview deletions without modifying anything
 
 ## How It Works
 
@@ -255,6 +256,9 @@ recovery_info: |
 ## Examples
 
 \`\`\`bash
+# Preview which branches would be deleted (safe, no modifications)
+vibe-validate cleanup --dry-run
+
 # Run cleanup (always YAML output)
 vibe-validate cleanup
 
@@ -306,9 +310,13 @@ git checkout -b feature/old-branch <SHA>
 4. **Complete context upfront** (no follow-up questions needed)
 5. **Switches away from current branch** if it needs cleanup
 
+## Options
+
+- \`--dry-run\` - Preview which branches would be deleted (sets \`dryRun: true\`, \`wouldDelete: [...]\`, \`autoDeleted: []\` in output)
+
 ## Breaking Changes from v0.17.x
 
-- **Removed options**: No --main-branch, --dry-run, --yaml (always YAML now)
+- **Removed options**: No --main-branch, --yaml (always YAML now)
 - **GitHub CLI required**: No graceful degradation (error if missing)
 - **Output format changed**: New structured YAML format
 - **No human-readable mode**: YAML-only for LLM consumption

--- a/packages/cli/test/commands/cleanup.test.ts
+++ b/packages/cli/test/commands/cleanup.test.ts
@@ -13,6 +13,33 @@ vi.mock('@vibe-validate/git', async () => {
   };
 });
 
+type CleanupMockResult = Awaited<ReturnType<typeof git.cleanupBranches>>;
+
+/**
+ * Build a minimal cleanup result for mocking. Tests override only the fields
+ * they care about; everything else defaults to a healthy "no branches" outcome.
+ */
+function createCleanupMockResult(overrides: Partial<CleanupMockResult> = {}): CleanupMockResult {
+  return {
+    context: {
+      repository: 'owner/repo',
+      remote: 'origin',
+      defaultBranch: 'main',
+      currentBranch: 'main',
+      switchedBranch: false,
+    },
+    autoDeleted: [],
+    needsReview: [],
+    summary: {
+      autoDeletedCount: 0,
+      needsReviewCount: 0,
+      totalBranchesAnalyzed: 0,
+    },
+    recoveryInfo: 'Deleted branches are recoverable for 30 days via git reflog',
+    ...overrides,
+  };
+}
+
 describe('cleanup command', () => {
   let env: CommanderTestEnv;
 
@@ -42,69 +69,37 @@ describe('cleanup command', () => {
       expect(command?.description()).toBe('Comprehensive branch cleanup with GitHub integration');
     });
 
-    it('should have no custom options (YAML-only, no flags)', () => {
+    it('should expose --dry-run option', () => {
       cleanupCommand(env.program);
 
       const command = env.program.commands.find(cmd => cmd.name() === 'cleanup');
-      // Should have no custom options (Commander adds standard --help option)
-      expect(command?.options.length).toBe(0); // No custom options
+      const optionNames = command?.options.map(opt => opt.long) ?? [];
+      expect(optionNames).toEqual(['--dry-run']);
     });
   });
 
   describe('cleanup execution', () => {
     it('should call cleanupBranches function', async () => {
-      const mockResult = {
-        context: {
-          repository: 'owner/repo',
-          remote: 'origin',
-          defaultBranch: 'main',
-          currentBranch: 'main',
-          switchedBranch: false,
-        },
-        autoDeleted: [],
-        needsReview: [],
-        summary: {
-          autoDeletedCount: 0,
-          needsReviewCount: 0,
-          totalBranchesAnalyzed: 0,
-        },
-        recoveryInfo: 'Deleted branches are recoverable for 30 days via git reflog',
-      };
-
-      vi.mocked(git.cleanupBranches).mockResolvedValue(mockResult);
+      vi.mocked(git.cleanupBranches).mockResolvedValue(createCleanupMockResult());
 
       cleanupCommand(env.program);
 
       try {
         await env.program.parseAsync(['cleanup'], { from: 'user' });
       } catch (error) { // NOSONAR - Commander.js throws on exitOverride, caught to test exit codes
-        // Expected exception from Commander.js exitOverride
         expect(error).toBeDefined();
       }
 
-      expect(git.cleanupBranches).toHaveBeenCalledWith();
+      expect(git.cleanupBranches).toHaveBeenCalledWith({ dryRun: undefined });
     });
 
     it('should output YAML on success', async () => {
-      const mockResult = {
-        context: {
-          repository: 'owner/repo',
-          remote: 'origin',
-          defaultBranch: 'main',
-          currentBranch: 'main',
-          switchedBranch: false,
-        },
-        autoDeleted: [{ name: 'feature/test', reason: 'merged_to_main', recoveryCommand: 'git reflog' }],
-        needsReview: [],
-        summary: {
-          autoDeletedCount: 1,
-          needsReviewCount: 0,
-          totalBranchesAnalyzed: 1,
-        },
-        recoveryInfo: 'Deleted branches are recoverable for 30 days via git reflog',
-      };
-
-      vi.mocked(git.cleanupBranches).mockResolvedValue(mockResult);
+      vi.mocked(git.cleanupBranches).mockResolvedValue(
+        createCleanupMockResult({
+          autoDeleted: [{ name: 'feature/test', reason: 'merged_to_main', recoveryCommand: 'git reflog' }],
+          summary: { autoDeletedCount: 1, needsReviewCount: 0, totalBranchesAnalyzed: 1 },
+        })
+      );
 
       cleanupCommand(env.program);
 
@@ -115,7 +110,32 @@ describe('cleanup command', () => {
       }
 
       // Verify cleanupBranches was called (output format tested in branch-cleanup.test.ts)
-      expect(git.cleanupBranches).toHaveBeenCalledWith();
+      expect(git.cleanupBranches).toHaveBeenCalledWith({ dryRun: undefined });
+    });
+
+    it('should pass dryRun=true when --dry-run flag is provided', async () => {
+      vi.mocked(git.cleanupBranches).mockResolvedValue(
+        createCleanupMockResult({
+          dryRun: true,
+          wouldDelete: [{ name: 'feature/test', reason: 'merged_to_main', recoveryCommand: 'git reflog' }],
+          summary: {
+            autoDeletedCount: 0,
+            wouldDeleteCount: 1,
+            needsReviewCount: 0,
+            totalBranchesAnalyzed: 1,
+          },
+        })
+      );
+
+      cleanupCommand(env.program);
+
+      try {
+        await env.program.parseAsync(['cleanup', '--dry-run'], { from: 'user' });
+      } catch (error) { // NOSONAR - Commander.js throws on exitOverride
+        expect(error).toBeDefined();
+      }
+
+      expect(git.cleanupBranches).toHaveBeenCalledWith({ dryRun: true });
     });
 
     it('should handle errors and output YAML error format', async () => {
@@ -132,7 +152,7 @@ describe('cleanup command', () => {
       }
 
       // Verify cleanupBranches was called
-      expect(git.cleanupBranches).toHaveBeenCalledWith();
+      expect(git.cleanupBranches).toHaveBeenCalledWith({ dryRun: undefined });
     });
   });
 

--- a/packages/git/src/branch-cleanup.ts
+++ b/packages/git/src/branch-cleanup.ts
@@ -546,8 +546,16 @@ export async function enrichWithGitHubData(
 export interface CleanupResult {
   /** Context about the cleanup operation */
   context: CleanupContext;
-  /** Branches that were auto-deleted */
+  /** True if this was a dry-run (no branches actually deleted) */
+  dryRun?: boolean;
+  /** Branches that were auto-deleted (empty in dry-run mode) */
   autoDeleted: Array<{
+    name: string;
+    reason: string;
+    recoveryCommand: string;
+  }>;
+  /** Branches that would have been auto-deleted (only present in dry-run mode) */
+  wouldDelete?: Array<{
     name: string;
     reason: string;
     recoveryCommand: string;
@@ -563,6 +571,8 @@ export interface CleanupResult {
   /** Summary statistics */
   summary: {
     autoDeletedCount: number;
+    /** Only present in dry-run mode */
+    wouldDeleteCount?: number;
     needsReviewCount: number;
     totalBranchesAnalyzed: number;
   };
@@ -702,20 +712,36 @@ export function tryDeleteBranch(gitFacts: BranchGitFacts): { deleted: boolean; e
 
 /**
  * Categorize branches into auto-delete and needs-review
+ *
+ * In dry-run mode, safe branches are reported in `wouldDelete` and never
+ * passed to `tryDeleteBranch` (so the filesystem is not touched).
  */
 export function categorizeBranches(
-  analyses: BranchAnalysis[]
+  analyses: BranchAnalysis[],
+  options: { dryRun?: boolean } = {}
 ): {
   autoDeleted: CleanupResult['autoDeleted'];
+  wouldDelete: NonNullable<CleanupResult['wouldDelete']>;
   needsReview: CleanupResult['needsReview'];
 } {
+  const { dryRun = false } = options;
   const autoDeleted: CleanupResult['autoDeleted'] = [];
+  const wouldDelete: NonNullable<CleanupResult['wouldDelete']> = [];
   const branchesNeedingReview: CleanupResult['needsReview'] = [];
 
   for (const analysis of analyses) {
     const { gitFacts, githubFacts, assessment } = analysis;
 
     if (isAutoDeleteSafe(gitFacts)) {
+      if (dryRun) {
+        wouldDelete.push({
+          name: gitFacts.name,
+          reason: 'merged_to_main',
+          recoveryCommand: assessment.recoveryCommand,
+        });
+        continue;
+      }
+
       const result = tryDeleteBranch(gitFacts);
 
       if (result.deleted) {
@@ -744,7 +770,7 @@ export function categorizeBranches(
     }
   }
 
-  return { autoDeleted, needsReview: branchesNeedingReview };
+  return { autoDeleted, wouldDelete, needsReview: branchesNeedingReview };
 }
 
 /**
@@ -755,12 +781,18 @@ export function categorizeBranches(
  * 2. Gathers all local branches
  * 3. Analyzes each branch (git facts + GitHub enrichment)
  * 4. Categorizes branches (auto-delete vs needs-review)
- * 5. Deletes safe branches
+ * 5. Deletes safe branches (or reports `wouldDelete` if `dryRun` is true)
  * 6. Returns structured result with YAML-compatible format
  *
+ * @param options - Cleanup options
+ * @param options.dryRun - If true, preview the deletions without modifying anything
  * @returns Cleanup result with detailed analysis
  */
-export async function cleanupBranches(): Promise<CleanupResult> {
+export async function cleanupBranches(
+  options: { dryRun?: boolean } = {}
+): Promise<CleanupResult> {
+  const { dryRun = false } = options;
+
   // Step 1: Setup context (may switch branches)
   const context = await setupCleanupContext();
 
@@ -797,11 +829,11 @@ export async function cleanupBranches(): Promise<CleanupResult> {
   // Step 5: Enrich with GitHub data (throws if gh not available)
   await enrichWithGitHubData(analyses, context.repository);
 
-  // Step 6: Categorize and delete safe branches
-  const { autoDeleted, needsReview } = categorizeBranches(analyses);
+  // Step 6: Categorize and (unless dry-run) delete safe branches
+  const { autoDeleted, wouldDelete, needsReview } = categorizeBranches(analyses, { dryRun });
 
   // Step 7: Build result
-  return {
+  const result: CleanupResult = {
     context,
     autoDeleted,
     needsReview,
@@ -815,4 +847,12 @@ export async function cleanupBranches(): Promise<CleanupResult> {
       '  git reflog\n' +
       '  git checkout -b <branch-name> <SHA>',
   };
+
+  if (dryRun) {
+    result.dryRun = true;
+    result.wouldDelete = wouldDelete;
+    result.summary.wouldDeleteCount = wouldDelete.length;
+  }
+
+  return result;
 }

--- a/packages/git/test/branch-cleanup.test.ts
+++ b/packages/git/test/branch-cleanup.test.ts
@@ -11,6 +11,7 @@ import * as utils from '@vibe-validate/utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
+  cleanupBranches,
   detectDefaultBranch,
   isAutoDeleteSafe,
   needsReview,
@@ -1086,5 +1087,114 @@ describe('Branch Cleanup - categorizeBranches', () => {
     expect(wouldDelete).toHaveLength(0);
     expect(needsReview).toHaveLength(1);
     expect(needsReview[0].name).toBe('feature/squashed');
+  });
+});
+
+/**
+ * Resolve a single git-command invocation to its mocked return value. Pulled
+ * out of `mockGitForOrchestration` so neither function exceeds the cognitive-
+ * complexity ceiling; also makes the matching rules easy to read in isolation.
+ */
+function resolveOrchestrationGitCommand(args: string[], branches: string[]): string {
+  // Default-branch detection + repo setup
+  if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/origin/HEAD') {
+    return 'refs/heads/main';
+  }
+  if (args[0] === 'remote' && args[1] === 'get-url') {
+    return 'https://github.com/owner/repo.git';
+  }
+  // setupCleanupContext → getCurrentBranch
+  if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref' && args[2] === 'HEAD') {
+    return 'main';
+  }
+  // Branch listings (merged + all)
+  if (args[0] === 'branch' && (args[1] === '--merged' || args.includes('--format=%(refname:short)'))) {
+    return branches.join('\n');
+  }
+  // Per-branch fact gathering: pretend each branch tracks origin/<name>.
+  if (args[0] === 'config' && args[1] === '--get') {
+    if (args[2]?.endsWith('.merge')) return 'refs/heads/feature/done';
+    if (args[2]?.endsWith('.remote')) return 'origin';
+  }
+  if (args[0] === 'rev-parse' && args[1] === '--verify') return 'abc123'; // remote ref exists
+  if (args[0] === 'rev-list' && args[1] === '--count') return '0'; // no unpushed commits
+  if (args[0] === 'log' && args[1] === '-1') return '2026-01-01T00:00:00Z\nTest User';
+  return '';
+}
+
+/**
+ * Mock the git surface used by `cleanupBranches` orchestration. Parameterised
+ * over the set of branches to surface (so the dry-run tests can put a safe
+ * branch in front of `categorizeBranches`).
+ */
+function mockGitForOrchestration(branches: string[]): void {
+  vi.mocked(gitExecutor.execGitCommand).mockImplementation((args: string[]) =>
+    resolveOrchestrationGitCommand(args, branches)
+  );
+}
+
+describe('Branch Cleanup - cleanupBranches (orchestration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // gh CLI must be reachable for enrichWithGitHubData to proceed past its
+    // hard-requirement check; we mock the actual PR fetch below.
+    vi.mocked(utils.isToolAvailable).mockReturnValue(true);
+    vi.mocked(ghCommands.listPullRequests).mockReturnValue([]);
+  });
+
+  it('emits dryRun fields and zero counts when there are no local branches', async () => {
+    mockGitForOrchestration([]); // empty branch listing
+
+    const result = await cleanupBranches({ dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.wouldDelete).toEqual([]);
+    expect(result.autoDeleted).toEqual([]);
+    expect(result.needsReview).toEqual([]);
+    expect(result.summary.wouldDeleteCount).toBe(0);
+    expect(result.summary.autoDeletedCount).toBe(0);
+    expect(result.summary.totalBranchesAnalyzed).toBe(0);
+
+    // Critical safety property: `git branch -d` is NEVER called in dry-run.
+    const branchDeleteCalls = vi.mocked(gitExecutor.execGitCommand).mock.calls.filter(
+      ([args]) => args[0] === 'branch' && (args[1] === '-d' || args[1] === '-D')
+    );
+    expect(branchDeleteCalls).toHaveLength(0);
+  });
+
+  it('populates wouldDelete (not autoDeleted) when safe branches exist in dry-run', async () => {
+    mockGitForOrchestration(['feature/done']);
+
+    const result = await cleanupBranches({ dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.autoDeleted).toEqual([]);
+    expect(result.wouldDelete).toHaveLength(1);
+    expect(result.wouldDelete?.[0]).toMatchObject({
+      name: 'feature/done',
+      reason: 'merged_to_main',
+    });
+    expect(result.summary.wouldDeleteCount).toBe(1);
+    expect(result.summary.autoDeletedCount).toBe(0);
+    expect(result.summary.totalBranchesAnalyzed).toBe(1);
+
+    // No mutation: branch -d / -D never invoked even though a safe branch
+    // existed and would have been auto-deleted in non-dry-run mode.
+    const branchDeleteCalls = vi.mocked(gitExecutor.execGitCommand).mock.calls.filter(
+      ([args]) => args[0] === 'branch' && (args[1] === '-d' || args[1] === '-D')
+    );
+    expect(branchDeleteCalls).toHaveLength(0);
+  });
+
+  it('omits dryRun fields entirely when called without options (backward compat)', async () => {
+    mockGitForOrchestration([]);
+
+    const result = await cleanupBranches();
+
+    expect(result.dryRun).toBeUndefined();
+    expect(result.wouldDelete).toBeUndefined();
+    expect(result.summary.wouldDeleteCount).toBeUndefined();
+    expect(result.autoDeleted).toEqual([]);
+    expect(result.needsReview).toEqual([]);
   });
 });

--- a/packages/git/test/branch-cleanup.test.ts
+++ b/packages/git/test/branch-cleanup.test.ts
@@ -1029,4 +1029,62 @@ describe('Branch Cleanup - categorizeBranches', () => {
     expect(needsReview).toHaveLength(1);
     expect(needsReview[0].name).toBe('feature/review');
   });
+
+  it('should NOT invoke git branch -d when dryRun is true', () => {
+    vi.mocked(gitExecutor.execGitCommand).mockReturnValue('');
+
+    const analyses: BranchAnalysis[] = [
+      {
+        gitFacts: createBranchFacts({
+          name: 'feature/safe',
+          mergedToMain: true,
+          unpushedCommitCount: 0,
+        }),
+        assessment: {
+          summary: 'Auto-delete safe',
+          deleteCommand: 'git branch -D feature/safe',
+          recoveryCommand: 'git reflog | grep feature/safe',
+        },
+      },
+    ];
+
+    const { autoDeleted, wouldDelete, needsReview } = categorizeBranches(analyses, { dryRun: true });
+
+    expect(autoDeleted).toHaveLength(0);
+    expect(wouldDelete).toHaveLength(1);
+    expect(wouldDelete[0].name).toBe('feature/safe');
+    expect(wouldDelete[0].reason).toBe('merged_to_main');
+    expect(needsReview).toHaveLength(0);
+    // Critical safety property: no git mutation in dry-run
+    expect(gitExecutor.execGitCommand).not.toHaveBeenCalled();
+  });
+
+  it('should still surface needs-review branches in dryRun mode', () => {
+    const analyses: BranchAnalysis[] = [
+      {
+        gitFacts: createBranchFacts({
+          name: 'feature/squashed',
+          mergedToMain: false,
+          remoteStatus: 'deleted',
+          unpushedCommitCount: 0,
+          daysSinceActivity: 45,
+        }),
+        githubFacts: createGitHubFacts({
+          prState: 'merged',
+          mergeMethod: 'squash',
+        }),
+        assessment: {
+          summary: 'Needs review',
+          deleteCommand: 'git branch -D feature/squashed',
+          recoveryCommand: 'git reflog | grep feature/squashed',
+        },
+      },
+    ];
+
+    const { wouldDelete, needsReview } = categorizeBranches(analyses, { dryRun: true });
+
+    expect(wouldDelete).toHaveLength(0);
+    expect(needsReview).toHaveLength(1);
+    expect(needsReview[0].name).toBe('feature/squashed');
+  });
 });


### PR DESCRIPTION
## Description
v0.18.0 removed --dry-run from `vv cleanup`, but the underlying operation (`git branch -D`) is permanent and the help text still mentioned the flag.
  Restore as a safety net:

  - `cleanupBranches({ dryRun })` threads the flag through to `categorizeBranches`, which skips `tryDeleteBranch` entirely in dry-run mode — no git mutation
   can occur.
  - YAML output gains an optional `wouldDelete: []` array mirroring the existing `autoDeleted` shape, plus `dryRun: true` and `summary.wouldDeleteCount`.
  Non-dry-run output is byte-stable.
  - Removed the stale "Removed options: --dry-run" line from the cleanup verbose help; added a dry-run example.

  ## Type of Change

  - [X] Bug fix (non-breaking change that fixes an issue)
  - [X] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Dependency update
  - [ ] Other (please describe):

  ## Related Issues

  Fixes #164 (in part)
  Relates to #164

  ## Changes Made

  **`packages/git/src/branch-cleanup.ts`**
  - `CleanupResult` interface gains three optional fields: `dryRun?: boolean`, `wouldDelete?: Array<...>`, `summary.wouldDeleteCount?: number`. All are
  omitted in non-dry-run mode so existing YAML consumers see byte-identical output.
  - `cleanupBranches({ dryRun?: boolean })` — new options object; threads `dryRun` to `categorizeBranches`.
  - `categorizeBranches(analyses, { dryRun })` — in dry-run, **the `tryDeleteBranch` call is skipped entirely**; safe branches are pushed into `wouldDelete`
   with the same `{ name, reason, recoveryCommand }` shape as `autoDeleted`. The needs-review path is unchanged.

  **`packages/cli/src/commands/cleanup.ts`**
  - `.option('--dry-run', 'Preview which branches would be deleted without modifying anything')` added.
  - `cleanupCommand` passes `{ dryRun: options.dryRun }` to `cleanupBranches`.
  - Removed stale "Removed options: --dry-run" line from the verbose help; replaced with an actual options section.
  - Added a `vibe-validate cleanup --dry-run` example to the verbose help.

  **Tests**
  - `packages/git/test/branch-cleanup.test.ts`: 2 new tests — `categorizeBranches` with `dryRun: true` populates `wouldDelete` and
  **`expect(gitExecutor.execGitCommand).not.toHaveBeenCalled()`** (the strongest possible safety assertion); needs-review still works in dry-run.
  - `packages/cli/test/commands/cleanup.test.ts`: updated the "no options" assertion to expect `--dry-run`; added a new test that asserts `cleanupBranches`
  is called with `{ dryRun: true }` when the flag is passed.
  - Extracted module-scope helper `createCleanupMockResult()` to keep test duplication under the 3% jscpd threshold.

  **Generated docs**
  - `docs/skills/vibe-validate/cli-reference.md` regenerated via `pnpm generate-cli-docs` to pick up the new option.

  ## Testing

  ### Test Coverage

  - [X] Unit tests added/updated
  - [ ] Integration tests added/updated *(not needed — no new I/O paths)*
  - [X] All existing tests pass
  - [X] Test coverage maintained or improved

  **New tests (3):**
  - `branch-cleanup.test.ts` — "should NOT invoke git branch -d when dryRun is true" (the critical safety property)
  - `branch-cleanup.test.ts` — "should still surface needs-review branches in dryRun mode"
  - `cleanup.test.ts` — "should pass dryRun=true when --dry-run flag is provided"

  **Updated tests (2):**
  - `cleanup.test.ts` — "should have no custom options" → "should expose --dry-run option"
  - `cleanup.test.ts` — existing execution tests updated to expect `{ dryRun: undefined }` in `cleanupBranches` call args

  ### Manual Testing

  **Tested on:**
  - OS: Ubuntu (WSL2 on Windows 11) — Linux 6.6.87.2-microsoft-standard-WSL2
  - Node.js version: 22.22.3 (project requires >=20.0.0; CI matrix is 22 + 24)
  - Package manager: pnpm 9.15.0

  **Test scenarios:**
  1. `vv cleanup --dry-run` against a repo with mixed merged / squash-merged / open branches → YAML shows `dryRun: true`, `wouldDelete: [...]` containing
  only the auto-delete-safe branches, `autoDeleted: []`, `needsReview: [...]` populated as before. No git branches were modified.
  2. `vv cleanup` (no flag) → output is byte-identical to pre-PR (verified by inspecting the YAML structure; the new optional fields are omitted).
  3. `vv cleanup --help` lists `--dry-run` under options; `vv cleanup --help --verbose` shows the new dry-run example in the rendered Markdown.

  ## Validation

  - [X] `pnpm validate` passes locally
  - [X] No new linting errors
  - [X] TypeScript compilation succeeds
  - [X] All tests pass

  ## Documentation

  - [ ] README.md updated *(not needed)*
  - [X] JSDoc comments added/updated for public APIs *(updated `CleanupResult`, `cleanupBranches`, `categorizeBranches`)*
  - [ ] CHANGELOG.md updated *(deferred — keeping `[Unreleased]` clean per project convention until the larger #164 series lands; happy to add an entry on
  request)*
  - [ ] Migration guide provided *(no breaking change)*
  - [X] Examples updated *(cleanup verbose help now shows a dry-run example)*

  ## Breaking Changes

  None. `cleanupBranches()` now accepts an optional options bag (defaults to `{}`), so existing callers with no arguments continue to work. The YAML schema
  only adds optional fields when in dry-run mode; non-dry-run output is byte-stable with the v0.18.0+ format.

  **What breaks:** N/A

  **Migration path:** N/A

  ## Performance Impact

  - [X] No performance impact
  - [ ] Performance improvement (describe below)
  - [ ] Potential performance regression (describe and justify below)

  **Details:**

  One boolean check per branch in the categorize loop. In dry-run mode the per-branch `git branch -d` subprocess is skipped, so dry-run is strictly faster
  than the real cleanup.

  ## Security Considerations

  - [ ] No security impact
  - [X] Security improvement (describe below)
  - [ ] Potential security concern (describe and explain mitigation below)

  **Details:**

  Restores a long-standing safety net for a permanent, recovery-via-reflog-only operation (`git branch -D`). The v0.18.0 cleanup pipeline is opinionated and
   auto-deletes 100%-safe branches, but the safety heuristic + GitHub enrichment, however good, is not infallible. A user running `vv cleanup --dry-run`
  before committing now gets a structured preview of which branches will be deleted and the recovery commands, with **zero git mutation** — enforced by
  skipping `tryDeleteBranch` at the source, not by mocking or short-circuiting downstream.

  ## Checklist

  - [X] My code follows the project's coding standards
  - [X] I have performed a self-review of my own code
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
  - [X] New and existing unit tests pass locally with my changes
  - [X] Any dependent changes have been merged and published *(none — branched off latest `origin/main`)*
  - [X] I have run `pnpm validate` and all checks pass

  ## Screenshots/Recordings

  N/A — output is structured YAML; see "Test scenarios" above for the schema.

  ## Additional Context

  Sibling PRs in progress addressing the rest of #164:
  - **PR 2** — `create-extractor` UX papercuts: stale `test-extractor` references in post-creation help removed; new `--dry-run` flag for the scaffolder;
  non-TTY stdin no longer silently exits 0.
  - **PR 3** — new `vv test-extractor <path>` command for validating extractor plugins (interface, ReDoS, sandbox, samples, tests).
  - **PR 4** *(planned, follow-up)* — make `isolated-vm` an `optionalDependency` and wrap sandbox tests with `describe.skipIf(!isolatedVmAvailable)` so
  install doesn't fail on systems where the native binding can't compile. Discovered while QA'ing the above: `isolated-vm@6.0.2` requires V8 symbols
  (`v8::SourceLocation`, `v8::ValueSerializer::Delegate::HasCustomHostObject`) that only exist in Node 22+, even though `engines.node` says `>=20.0.0`. CI
  uses Node 22/24 so this didn't surface there.

  This PR is independent of PRs 2–4 and can land in any order.